### PR TITLE
Mjw/school member test

### DIFF
--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/init/TestDataInit.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/init/TestDataInit.java
@@ -39,33 +39,33 @@ public class TestDataInit {
 
     private void initSchool(){
         School school1 = new School();
-        school1.setSchoolName("테스트1 학교");
-        school1.setSchoolCoordinate("테스트1 좌표");
+        school1.setSchoolName("더미테스트1 학교");
+        school1.setSchoolCoordinate("더미테스트1 좌표");
 
         School school2 = new School();
-        school2.setSchoolName("테스트2 학교");
-        school2.setSchoolCoordinate("테스트2 좌표");
+        school2.setSchoolName("더미테스트2 학교");
+        school2.setSchoolCoordinate("더미테스트2 좌표");
         schoolService.join(school1);
         schoolService.join(school2);
     }
 
     private void initDepartment(){
-        School school1 = schoolRepository.findBySchoolName("테스트1 학교");
-        School school2 = schoolRepository.findBySchoolName("테스트2 학교");
+        School school1 = schoolRepository.findBySchoolName("더미테스트1 학교");
+        School school2 = schoolRepository.findBySchoolName("더미테스트2 학교");
         DepartmentFormDto dto1 = new DepartmentFormDto();
-        dto1.setDepartmentName("테스트1 학과1");
+        dto1.setDepartmentName("더미테스트1 학과1");
         dto1.setSchoolId(school1.getId());
 
         DepartmentFormDto dto2 = new DepartmentFormDto();
-        dto2.setDepartmentName("테스트1 학과2");
+        dto2.setDepartmentName("더미테스트1 학과2");
         dto2.setSchoolId(school1.getId());
 
         DepartmentFormDto dto3 = new DepartmentFormDto();
-        dto3.setDepartmentName("테스트2 학과1");
+        dto3.setDepartmentName("더미테스트2 학과1");
         dto3.setSchoolId(school2.getId());
 
         DepartmentFormDto dto4 = new DepartmentFormDto();
-        dto4.setDepartmentName("테스트2 학과2");
+        dto4.setDepartmentName("더미테스트2 학과2");
         dto4.setSchoolId(school2.getId());
 
         departmentService.join(school1.getId(), dto1);
@@ -75,23 +75,23 @@ public class TestDataInit {
     }
 
     private void initMember(){
-        School school1 = schoolRepository.findBySchoolName("테스트1 학교");
-        School school2 = schoolRepository.findBySchoolName("테스트2 학교");
+        School school1 = schoolRepository.findBySchoolName("더미테스트1 학교");
+        School school2 = schoolRepository.findBySchoolName("더미테스트2 학교");
 
         List<Department> departments1 = departmentRepository.findBySchool_Id(school1.getId());
         List<Department> departments2 = departmentRepository.findBySchool_Id(school2.getId());
 
-        MemberFormBDto dto1 = createMemberFormDto("test1", "test123!", "테스트1", "test1@naver.com",
+        MemberFormBDto dto1 = createMemberFormDto("dummyTest1", "test123!", "더미테스트1", "dummytest1@naver.com",
                 GenderType.MAN, school1.getId(), departments1.get(0).getId());
-        MemberFormBDto dto2 = createMemberFormDto("test2", "test123!", "테스트2", "test2@naver.com",
+        MemberFormBDto dto2 = createMemberFormDto("dummyTest2", "test123!", "더미테스트2", "dummytest2@naver.com",
                 GenderType.MAN, school1.getId(), departments1.get(0).getId());
-        MemberFormBDto dto3 = createMemberFormDto("test3", "test123!", "테스트3", "test3@naver.com",
+        MemberFormBDto dto3 = createMemberFormDto("dummyTest3", "test123!", "더미테스트3", "dummytest3@naver.com",
                 GenderType.MAN, school1.getId(), departments1.get(1).getId());
-        MemberFormBDto dto4 = createMemberFormDto("test4", "test123!", "테스트4", "test4@naver.com",
+        MemberFormBDto dto4 = createMemberFormDto("dummyTest4", "test123!", "더미테스트4", "dummytest4@naver.com",
                 GenderType.WOMAN, school2.getId(), departments2.get(0).getId());
-        MemberFormBDto dto5 = createMemberFormDto("test5", "test123!", "테스트5", "test5@naver.com",
+        MemberFormBDto dto5 = createMemberFormDto("dummyTest5", "test123!", "더미테스트5", "dummytest5@naver.com",
                 GenderType.WOMAN, school2.getId(), departments2.get(1).getId());
-        MemberFormBDto dto6 = createMemberFormDto("test6", "test123!", "테스트6", "test6@naver.com",
+        MemberFormBDto dto6 = createMemberFormDto("dummyTest6", "test123!", "더미테스트6", "dummytest6@naver.com",
                 GenderType.WOMAN, school2.getId(), departments2.get(1).getId());
 
         memberService.join(dto1);

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/repository/member/MemberRepositoryCustom.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/repository/member/MemberRepositoryCustom.java
@@ -10,6 +10,7 @@ public interface MemberRepositoryCustom {
     Member findById(String id);
     List<Member> findByName(String name);
     List<Member> findByNameAndSchool_SchoolName(String name, String schoolName);
+    List<Member> findByDepartment_Id(Long id);
     List<Member> search(MemberSearch memberSearch);
     Member findByNickname(String nickname);
     Member findByEmail(String email);

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/repository/member/MemberRepositoryCustom.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/repository/member/MemberRepositoryCustom.java
@@ -11,6 +11,7 @@ public interface MemberRepositoryCustom {
     List<Member> findByName(String name);
     List<Member> findByNameAndSchool_SchoolName(String name, String schoolName);
     List<Member> findByDepartment_Id(Long id);
+    List<Member> findBySchool_SchoolId(Long id);
     List<Member> search(MemberSearch memberSearch);
     Member findByNickname(String nickname);
     Member findByEmail(String email);

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/repository/member/MemberRepositoryImpl.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/repository/member/MemberRepositoryImpl.java
@@ -10,6 +10,7 @@ import javax.persistence.EntityManager;
 import java.util.List;
 
 import static ProjectDoge.StudentSoup.entity.member.QMember.member;
+import static ProjectDoge.StudentSoup.entity.school.QDepartment.department;
 
 public class MemberRepositoryImpl implements MemberRepositoryCustom {
 
@@ -36,6 +37,17 @@ public class MemberRepositoryImpl implements MemberRepositoryCustom {
     @Override
     public List<Member> findByNameAndSchool_SchoolName(String name, String schoolName) {
         return null;
+    }
+
+    @Override
+    public List<Member> findByDepartment_Id(Long id) {
+        JPQLQuery<Member> query = queryFactory.select(member)
+                .from(department)
+                .leftJoin(department.members, member)
+                .fetchJoin()
+                .where(department.id.eq(id));
+
+        return query.fetch();
     }
 
     @Override

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/repository/member/MemberRepositoryImpl.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/repository/member/MemberRepositoryImpl.java
@@ -42,8 +42,8 @@ public class MemberRepositoryImpl implements MemberRepositoryCustom {
     @Override
     public List<Member> findByDepartment_Id(Long id) {
         JPQLQuery<Member> query = queryFactory.select(member)
-                .from(department)
-                .leftJoin(department.members, member)
+                .from(member)
+                .leftJoin(member.department, department)
                 .fetchJoin()
                 .where(department.id.eq(id));
 

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/repository/member/MemberRepositoryImpl.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/repository/member/MemberRepositoryImpl.java
@@ -11,6 +11,7 @@ import java.util.List;
 
 import static ProjectDoge.StudentSoup.entity.member.QMember.member;
 import static ProjectDoge.StudentSoup.entity.school.QDepartment.department;
+import static ProjectDoge.StudentSoup.entity.school.QSchool.school;
 
 public class MemberRepositoryImpl implements MemberRepositoryCustom {
 
@@ -46,6 +47,19 @@ public class MemberRepositoryImpl implements MemberRepositoryCustom {
                 .leftJoin(member.department, department)
                 .fetchJoin()
                 .where(department.id.eq(id));
+
+        return query.fetch();
+    }
+
+    @Override
+    public List<Member> findBySchool_SchoolId(Long id) {
+        JPQLQuery<Member> query = queryFactory.select(member)
+                .from(member)
+                .leftJoin(member.school, school)
+                .fetchJoin()
+                .leftJoin(member.department, department)
+                .fetchJoin()
+                .where(school.id.eq(id));
 
         return query.fetch();
     }

--- a/StudentSoup/src/test/java/ProjectDoge/StudentSoup/member/MemberEntityTest.java
+++ b/StudentSoup/src/test/java/ProjectDoge/StudentSoup/member/MemberEntityTest.java
@@ -222,7 +222,47 @@ public class MemberEntityTest {
             assertThat(members.contains(member1)).isEqualTo(true);
             assertThat(members.contains(member2)).isEqualTo(true);
         }
+
+        @Test
+        void 학교내_회원검증() throws Exception {
+            //given
+            MemberFormADto formA1 = createMemberFormA("test1", "test123!");
+            MemberFormBDto formB1 = createMemberFormB(formA1);
+            formB1.setNickname("테스트1");
+            formB1.setGender(GenderType.MAN);
+            formB1.setSchoolId(schoolId);
+            formB1.setDepartmentId(departmentId);
+            formB1.setEmail("test1@naver.com");
+            Long member1Id = memberService.join(formB1);
+
+            MemberFormADto formA2 = createMemberFormA("test2", "test123!");
+            MemberFormBDto formB2 = createMemberFormB(formA2);
+            formB2.setNickname("테스트2");
+            formB2.setGender(GenderType.MAN);
+            formB2.setSchoolId(schoolId);
+            formB2.setDepartmentId(departmentId);
+            formB2.setEmail("test2@naver.com");
+            Long member2Id = memberService.join(formB2);
+
+            //when
+            List<Member> members = memberRepository.findBySchool_SchoolId(schoolId);
+            //then
+            for (Member member : members) {
+                log.info("memberId : {}, id : {}, nickName : {}", member.getMemberId(), member.getId(), member.getNickname());
+            }
+            // 회원 검증
+            assertThat(members.get(0).getMemberId()).isEqualTo(member1Id);
+            assertThat(members.get(1).getMemberId()).isEqualTo(member2Id);
+            // 학과 검증
+            log.info("학과 검증을 시작하였습니다.");
+            assertThat(members.get(0).getDepartment().getId()).isEqualTo(departmentId);
+            // 학교 검증
+            log.info("학교 검증을 시작하였습니다.");
+            assertThat(members.get(0).getSchool().getId()).isEqualTo(schoolId);
+        }
     }
+
+
 
         private School createSchool() {
             School school = new School();


### PR DESCRIPTION
## 1. Changes
- 학교 내에 등록된 모든 학생들의 학교와 학과를 한 번에 볼 수 있도록 테스트 하였습니다.
- 이 때, 여러 멤버 조회 시 select 문이 여러 번 발생하지 않고 한 번으로 가지고 올 수 있도록 성능 개선 하였습니다.
## 2. Screenshot
- 
![image](https://user-images.githubusercontent.com/74203371/209290833-5d837287-2ef8-49fe-a982-755c517739db.png)
![image](https://user-images.githubusercontent.com/74203371/209291190-67c1fa30-b973-4e0d-8790-9f2fd5f08644.png)
![image](https://user-images.githubusercontent.com/74203371/209291286-a793ae98-c6e4-40eb-83a4-809ca468d0db.png)

## 3. Issues

1. 회원가입 로직을 테스트 하고 한 가지 예외 상황이 떠올랐습니다.
 저희가 회원가입을 할 때 보면 이미 등록된 아이디 인지 검증을 하고 다음 회원가입 화면으로 넘어가서 세부 내용을 작성하게되는데
 이때 다시 새로운 회원가입으로 넘어와서 지금 등록 진행 중인 아이디로 회원가입해도 동일하게 다음 페이지로 넘어가게 됩니다.
 결국 회원은 모든 개인정보를 다 적었을 때, 이전에 자신보다 먼저 등록한 사람이 있으면 다시 id pwd를 입력해야 하는 상황이 발생합니다.
 

## 4. To Reviewer

- 임시 검증 테이블을 만들어서 검증을 해야하는지.. 그렇게 되면 다음에 넘어갔을 때 클라이언트가 가입을 안하고 나오는 경우에는 DB에 있는
 검증 내용을 지워야하는데 그 타이밍도 잡을 수가 없어서 좋은 방법 있으면 알려주셨으면 합니다! 

## 5. Plans
- [x] - 로그인 검증 테스트 작성
- [ ] - 이미지 파일 등록 서비스 작성
