### PR TITLE
- mjw/testInitFix

### DIFF
--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/init/TestDataInit.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/init/TestDataInit.java
@@ -11,6 +11,8 @@ import ProjectDoge.StudentSoup.service.DepartmentService;
 import ProjectDoge.StudentSoup.service.MemberService;
 import ProjectDoge.StudentSoup.service.SchoolService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
 
 import javax.annotation.PostConstruct;
@@ -26,7 +28,7 @@ public class TestDataInit {
     private final DepartmentService departmentService;
 
 
-    @PostConstruct
+    @EventListener(ApplicationReadyEvent.class)
     public void init(){
         initSchoolAndDepartment();
         initMember();


### PR DESCRIPTION
## 1. Changes
- 테스트 더미데이터를 생성하기 위한 애노테이션을 @PostConstruct에서 @EventListener로 변경하였습니다.
- @PostConstruct를 사용하게 되면 스프링 AOP와 관련된 내용이 전부 처리되지 않은 채 넘어갈 수 있는데,
스프링 AOP가 하는 역할 중에 데이터베이스의 트랜잭션을 관리하는 @Transactional도 스프링 AOP가 관리하기때문에,
스프링 AOP가 실행 된 이후에 선택하는 @EventListener로 변경하였습니다.

## 2. Screenshot

-  ![image](https://user-images.githubusercontent.com/74203371/209435226-9453e266-cbed-49c8-8c7a-a832e35a0e40.png)


## 3. Issues

1. 
2. 


## 4. To Reviewer

- @xogns4909 공부에 참고하세요

## 5. Plans
- [ ] - 
- [ ] - 
