### PR TITLE
Mjw/memberTestFix

### DIFF
--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/init/TestDataInit.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/init/TestDataInit.java
@@ -12,6 +12,7 @@ import ProjectDoge.StudentSoup.service.MemberService;
 import ProjectDoge.StudentSoup.service.SchoolService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.annotation.Profile;
 import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
 
@@ -19,6 +20,7 @@ import javax.annotation.PostConstruct;
 import java.util.List;
 
 @Component
+@Profile("local")
 @RequiredArgsConstructor
 public class TestDataInit {
     private final MemberService memberService;

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/init/TestDataInit.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/init/TestDataInit.java
@@ -11,6 +11,8 @@ import ProjectDoge.StudentSoup.service.DepartmentService;
 import ProjectDoge.StudentSoup.service.MemberService;
 import ProjectDoge.StudentSoup.service.SchoolService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
 
 import javax.annotation.PostConstruct;
@@ -26,7 +28,7 @@ public class TestDataInit {
     private final DepartmentService departmentService;
 
 
-    @PostConstruct
+    @EventListener(ApplicationReadyEvent.class)
     public void init(){
         initSchoolAndDepartment();
         initMember();

--- a/StudentSoup/src/test/java/ProjectDoge/StudentSoup/member/MemberEntityTest.java
+++ b/StudentSoup/src/test/java/ProjectDoge/StudentSoup/member/MemberEntityTest.java
@@ -222,9 +222,6 @@ public class MemberEntityTest {
             assertThat(members.contains(member1)).isEqualTo(true);
             assertThat(members.contains(member2)).isEqualTo(true);
         }
-    }
-
-
         @Test
         void 학교내_회원검증() throws Exception {
             //given
@@ -262,9 +259,8 @@ public class MemberEntityTest {
             log.info("학교 검증을 시작하였습니다.");
             assertThat(members.get(0).getSchool().getId()).isEqualTo(schoolId);
         }
+
     }
-
-
         private School createSchool() {
             School school = new School();
             school.setSchoolName("테스트 학교");
@@ -294,7 +290,4 @@ public class MemberEntityTest {
             formB.setGender(GenderType.MAN);
             return formB;
         }
-
-
-
 }


### PR DESCRIPTION
## 1. Changes
- 테스트 데이터에 프로필을 적용하였습니다.
- 기존에 테스트 실행 시 메인에 있는 더미 데이터 추가 코드가 같이 실행되는 문제가 있었습니다.
- 더미데이터 생성 메소드를 메인에서만 실행되도록 코드에 @Profile 애노테이션을 추가하였습니다.
---
- 회원 테스트의 코드 영역이 벗어난 문제를 수정하였습니다.

## 2. Screenshot

- ![image](https://user-images.githubusercontent.com/74203371/209436338-cba6dfbd-f0d7-4cd2-942e-c1a032985b99.png)


## 3. Issues

1. 
2. 

## 4. To Reviewer

- @xogns4909 

## 5. Plans
- [ ] - File 생성 서비스 로직 작성
- [x] - 인터셉터를 활용한 로그 추가와
- [ ] - @ExceptionHandler 를 통한 실질적인 예외처리
