### PR TITLE
Mjw/log intercepter

### DIFF
--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/config/LogConfig.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/config/LogConfig.java
@@ -1,0 +1,17 @@
+package ProjectDoge.StudentSoup.config;
+
+import ProjectDoge.StudentSoup.interceptor.LogInterceptor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class LogConfig implements WebMvcConfigurer {
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(new LogInterceptor())
+                .order(1)
+                .addPathPatterns("/**");
+    }
+}

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/interceptor/LogInterceptor.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/interceptor/LogInterceptor.java
@@ -1,0 +1,47 @@
+package ProjectDoge.StudentSoup.interceptor;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.method.HandlerMethod;
+import org.springframework.web.servlet.HandlerInterceptor;
+import org.springframework.web.servlet.ModelAndView;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.util.UUID;
+
+@Slf4j
+public class LogInterceptor implements HandlerInterceptor {
+
+    public static final String LOG_ID = "logId";
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
+        String requestURI = (String)request.getAttribute("URI");
+
+        String uuid = UUID.randomUUID().toString();
+        request.setAttribute(LOG_ID, uuid);;
+
+        if (handler instanceof HandlerMethod) {
+            HandlerMethod hm = (HandlerMethod) handler;
+        }
+
+        log.info("preHandle REQUEST [{}][{}][{}]", uuid, requestURI, handler);
+        return true;
+    }
+
+    @Override
+    public void postHandle(HttpServletRequest request, HttpServletResponse response, Object handler, ModelAndView modelAndView) throws Exception {
+        log.info("postHandle [{}]", modelAndView);
+    }
+
+    @Override
+    public void afterCompletion(HttpServletRequest request, HttpServletResponse response, Object handler, Exception ex) throws Exception {
+        String requestURI = (String)request.getAttribute("URI");
+        String logId = (String)request.getAttribute(LOG_ID);
+
+        log.info("afterCompletion RESPONSE[{}][{}]", logId, requestURI);
+        if(ex != null){
+            log.error("afterCompletion Error", ex);
+        }
+    }
+}


### PR DESCRIPTION
## 1. Changes

- 페이지 이동 시 로그 저장 기능을 추가하고 등록하였습니다.
- 예외 발생 시 해당 문제가 발생한 로그를 추적하기 위해서 uuid를 사용하였습니다.

## 2. Screenshot

- ![Image](https://user-images.githubusercontent.com/74203371/209463932-3e423bd1-e990-437e-b7d9-9b67adb14b97.png)


## 3. Issues

1. 로그를 저장하기 위해서 데이터를 보내고 받을 때마다 "URI와 logId"를 key에 URI를 담아야하는데, 웹에서는 간단히 URI를 받을 수 있는데 HTTP API 통신은 따로 보내줘야 해서 어떻게 생각하시는지..! 다른 방법은 없을 지 여쭤봅니다!
2. 

## 4. To Reviewer

- 매 페이지 호출 시 URI와 logId를 받아야하는데, 혹시 실무에서는 해당 페이지 로그 명칭 보낼 때 알려주실 수 있으면 감사하겠습니다!

## 5. Plans
- [ ] - 파일 이미지 등록 서비스 개발
- [x] - HTTP API 통신 정상 확인
