### PR TITLE
mjw/fixHomeMapping

### DIFF
--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/controller/Index.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/controller/Index.java
@@ -21,7 +21,7 @@ public class Index {
 
     private final SchoolService schoolService;
 
-    @GetMapping("/home")
+    @GetMapping(value={"","/"})
     public List<SchoolIndexDTO> homeController(){
         log.info("homeController가 호출되었습니다.");
 


### PR DESCRIPTION
## 1. Changes
- api 호출 시 "/" 가능하도록 해두었습니다.

## 2. Screenshot

-

## 3. Issues

1. 꼭 API의 호출을 프론트엔드의 URI Router 컴포넌트 호출과 동일시 안해도 된다고 하네요!
2. 

## 4. To Reviewer

- 프론트엔드의 url Router로 컴포넌트 호출과  RestAPI 매핑을 알아보기 쉽게 하기 위해 호출 URI를 동일시했는데, 예림님도 얘기하시고 찾아보니 꼭 그렇게 안해도 된다고 하더라구요! 어떻게 하는게 좋을지 의견주세요! 

## 5. Plans
- [x] - 메인 페이지 예외처리
- [ ] - 
