### PR TITLE
Mjw/memberProfileImageUpdate

### DIFF
--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/controller/member/ProfileController.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/controller/member/ProfileController.java
@@ -1,0 +1,24 @@
+package ProjectDoge.StudentSoup.controller.member;
+
+import ProjectDoge.StudentSoup.dto.member.MemberDto;
+import ProjectDoge.StudentSoup.service.MemberService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+public class ProfileController {
+
+    private final MemberService memberService;
+
+    @PostMapping(value = "/members/edit/image", consumes = {MediaType.APPLICATION_JSON_VALUE, MediaType.MULTIPART_FORM_DATA_VALUE})
+    public MemberDto updateProfile(@RequestParam(value = "memberId") Long memberId, @RequestPart MultipartFile multipartFile){
+        log.info("받은 memberId : [{}], imageFile : [{}]", memberId, multipartFile.getOriginalFilename());
+
+        return memberService.memberProfileUpdate(memberId, multipartFile);
+    }
+}

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/exception/department/DepartmentIdNotSentException.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/exception/department/DepartmentIdNotSentException.java
@@ -1,0 +1,23 @@
+package ProjectDoge.StudentSoup.exception.department;
+
+public class DepartmentIdNotSentException extends RuntimeException {
+    public DepartmentIdNotSentException() {
+        super();
+    }
+
+    public DepartmentIdNotSentException(String message) {
+        super(message);
+    }
+
+    public DepartmentIdNotSentException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public DepartmentIdNotSentException(Throwable cause) {
+        super(cause);
+    }
+
+    protected DepartmentIdNotSentException(String message, Throwable cause, boolean enableSuppression, boolean writableStackTrace) {
+        super(message, cause, enableSuppression, writableStackTrace);
+    }
+}

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/exception/member/MemberIdNotSentException.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/exception/member/MemberIdNotSentException.java
@@ -1,0 +1,23 @@
+package ProjectDoge.StudentSoup.exception.member;
+
+public class MemberIdNotSentException extends RuntimeException {
+    public MemberIdNotSentException() {
+        super();
+    }
+
+    public MemberIdNotSentException(String message) {
+        super(message);
+    }
+
+    public MemberIdNotSentException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public MemberIdNotSentException(Throwable cause) {
+        super(cause);
+    }
+
+    protected MemberIdNotSentException(String message, Throwable cause, boolean enableSuppression, boolean writableStackTrace) {
+        super(message, cause, enableSuppression, writableStackTrace);
+    }
+}

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/exception/school/SchoolIdNotSentException.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/exception/school/SchoolIdNotSentException.java
@@ -1,0 +1,23 @@
+package ProjectDoge.StudentSoup.exception.school;
+
+public class SchoolIdNotSentException extends RuntimeException {
+    public SchoolIdNotSentException() {
+        super();
+    }
+
+    public SchoolIdNotSentException(String message) {
+        super(message);
+    }
+
+    public SchoolIdNotSentException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public SchoolIdNotSentException(Throwable cause) {
+        super(cause);
+    }
+
+    protected SchoolIdNotSentException(String message, Throwable cause, boolean enableSuppression, boolean writableStackTrace) {
+        super(message, cause, enableSuppression, writableStackTrace);
+    }
+}

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/exhandler/advice/DepartmentAdvice.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/exhandler/advice/DepartmentAdvice.java
@@ -1,5 +1,6 @@
 package ProjectDoge.StudentSoup.exhandler.advice;
 
+import ProjectDoge.StudentSoup.exception.department.DepartmentIdNotSentException;
 import ProjectDoge.StudentSoup.exception.department.DepartmentNotFoundException;
 import ProjectDoge.StudentSoup.exception.member.MemberNotFoundException;
 import ProjectDoge.StudentSoup.exhandler.ErrorResult;
@@ -17,5 +18,12 @@ public class DepartmentAdvice {
     public ErrorResult departmentNotFoundHandler(DepartmentNotFoundException e){
         log.error("[exceptionHandle] ex", e);
         return new ErrorResult("DepartmentNotFound", e.getMessage());
+    }
+
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @ExceptionHandler(DepartmentIdNotSentException.class)
+    public ErrorResult departmentIdNotSentHandler(DepartmentIdNotSentException e){
+        log.error("[exceptionHandle] ex", e);
+        return new ErrorResult("DepartmentIdNotSentException", e.getMessage());
     }
 }

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/exhandler/advice/MemberAdvice.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/exhandler/advice/MemberAdvice.java
@@ -1,5 +1,6 @@
 package ProjectDoge.StudentSoup.exhandler.advice;
 
+import ProjectDoge.StudentSoup.exception.member.MemberIdNotSentException;
 import ProjectDoge.StudentSoup.exception.member.MemberNotFoundException;
 import ProjectDoge.StudentSoup.exception.member.MemberValidationException;
 import ProjectDoge.StudentSoup.exhandler.ErrorResult;
@@ -24,5 +25,12 @@ public class MemberAdvice {
     public ErrorResult memberValidationHandler(MemberValidationException e){
         log.error("[exceptionHandle] ex", e);
         return new ErrorResult("MemberValidation", e.getMessage());
+    }
+
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @ExceptionHandler(MemberIdNotSentException.class)
+    public ErrorResult memberIdNotSentHandler(MemberIdNotSentException e){
+        log.error("[exceptionHandle] ex", e);
+        return new ErrorResult("MemberIdNotSent", e.getMessage());
     }
 }

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/exhandler/advice/SchoolAdvice.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/exhandler/advice/SchoolAdvice.java
@@ -1,0 +1,39 @@
+package ProjectDoge.StudentSoup.exhandler.advice;
+
+import ProjectDoge.StudentSoup.exception.member.MemberNotFoundException;
+import ProjectDoge.StudentSoup.exception.school.SchoolIdNotSentException;
+import ProjectDoge.StudentSoup.exception.school.SchoolNotFoundException;
+import ProjectDoge.StudentSoup.exception.school.SchoolValidationException;
+import ProjectDoge.StudentSoup.exhandler.ErrorResult;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+
+@Slf4j
+@RestControllerAdvice
+public class SchoolAdvice {
+
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @ExceptionHandler(SchoolIdNotSentException.class)
+    public ErrorResult schoolIdNotSentHandler(SchoolIdNotSentException e){
+        log.error("[exceptionHandle] ex", e);
+        return new ErrorResult("SchoolIdNotSentException", e.getMessage());
+    }
+
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @ExceptionHandler(SchoolNotFoundException.class)
+    public ErrorResult schoolNotFoundHandler(SchoolNotFoundException e){
+        log.error("[exceptionHandle] ex", e);
+        return new ErrorResult("SchoolNotFoundException", e.getMessage());
+    }
+
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @ExceptionHandler(SchoolValidationException.class)
+    public ErrorResult schoolValidationHandler(SchoolValidationException e){
+        log.error("[exceptionHandle] ex", e);
+        return new ErrorResult("SchoolValidationException", e.getMessage());
+    }
+}

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/service/DepartmentService.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/service/DepartmentService.java
@@ -3,7 +3,9 @@ package ProjectDoge.StudentSoup.service;
 import ProjectDoge.StudentSoup.dto.department.DepartmentFormDto;
 import ProjectDoge.StudentSoup.entity.school.Department;
 import ProjectDoge.StudentSoup.entity.school.School;
+import ProjectDoge.StudentSoup.exception.department.DepartmentIdNotSentException;
 import ProjectDoge.StudentSoup.exception.department.DepartmentNotFoundException;
+import ProjectDoge.StudentSoup.exception.school.SchoolIdNotSentException;
 import ProjectDoge.StudentSoup.exception.school.SchoolNotFoundException;
 import ProjectDoge.StudentSoup.repository.department.DepartmentRepository;
 import ProjectDoge.StudentSoup.repository.school.SchoolRepository;
@@ -54,11 +56,19 @@ public class DepartmentService {
     }
 
     public Department findOne(Long departmentId){
-        Optional<Department> department = departmentRepository.findById(departmentId);
-        return department.orElseThrow(() -> {
+        checkDepartmentIdSent(departmentId);
+
+        return departmentRepository.findById(departmentId).orElseThrow(() -> {
             log.info("findOne 메소드가 실행되었습니다. [{}]", departmentId);
             throw new DepartmentNotFoundException("학과를 조회하지 못했습니다.");
         });
+    }
+
+    private void checkDepartmentIdSent(Long departmentId) {
+        if(departmentId == null){
+            log.info("departmentId가 전송되지 않았습니다.");
+            throw new DepartmentIdNotSentException("departmentId가 전송되지 않았습니다.");
+        }
     }
 
     public Department findOneUsingDepartmentNameAndSchoolName(String departmentName, String schoolName){

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/service/MemberService.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/service/MemberService.java
@@ -164,7 +164,7 @@ public class MemberService {
         return member.getMemberId();
     }
 
-    private static void updateMemberField(AdminMemberUpdateForm dto, Member member) {
+    private void updateMemberField(AdminMemberUpdateForm dto, Member member) {
         member.setPwd(dto.getPwd());
         member.setEmail(dto.getEmail());
         member.setNickname(dto.getNickname());
@@ -209,14 +209,17 @@ public class MemberService {
     }
 
     public Member findOne(Long memberId) {
-        if(memberId == null){
-            log.info("멤버 프로필 업데이트 도중 memberId가 전송되지 않았습니다.");
-            throw new MemberIdNotSentException("memberId가 전송되지 않았습니다.");
-        }
-
+        checkMemberIdSent(memberId);
         return memberRepository.findById(memberId)
                 .orElseThrow(() -> {
                     throw new MemberNotFoundException("회원을 찾지 못하였습니다.");
                 });
+    }
+
+    private void checkMemberIdSent(Long memberId) {
+        if(memberId == null){
+            log.info("memberId가 전송되지 않았습니다.");
+            throw new MemberIdNotSentException("memberId가 전송되지 않았습니다.");
+        }
     }
 }

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/service/MemberService.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/service/MemberService.java
@@ -7,6 +7,7 @@ import ProjectDoge.StudentSoup.entity.file.ImageFile;
 import ProjectDoge.StudentSoup.entity.member.Member;
 import ProjectDoge.StudentSoup.entity.school.Department;
 import ProjectDoge.StudentSoup.entity.school.School;
+import ProjectDoge.StudentSoup.exception.member.MemberIdNotSentException;
 import ProjectDoge.StudentSoup.exception.member.MemberNotFoundException;
 import ProjectDoge.StudentSoup.exception.member.MemberNotSamePassword;
 import ProjectDoge.StudentSoup.exception.member.MemberValidationException;
@@ -187,7 +188,32 @@ public class MemberService {
         }
     }
 
+    @Transactional
+    public MemberDto memberProfileUpdate(Long memberId, MultipartFile multipartFile){
+        log.info("멤버 프로필이미지 업데이트가 시작되었습니다.");
+        Long fileId = fileService.join(multipartFile);
+        Member member = findOne(memberId);
+        return createProfileUpdateMemberDto(fileId, member);
+    }
+
+    private MemberDto createProfileUpdateMemberDto(Long fileId, Member member) {
+        if(fileId != null){
+            ImageFile imageFile = fileService.findOne(fileId);
+            member.setImageFile(imageFile);
+            log.info("멤버 프로필이미지가 업데이트 되었습니다. fileName : [{}]", imageFile.getFileOriginalName());
+            return new MemberDto().getMemberDto(member);
+        } else {
+            log.info("전송된 프로필 이미지가 없으므로, 프로필 이미지가 업데이트되지 않았습니다.");
+            return new MemberDto().getMemberDto(member);
+        }
+    }
+
     public Member findOne(Long memberId) {
+        if(memberId == null){
+            log.info("멤버 프로필 업데이트 도중 memberId가 전송되지 않았습니다.");
+            throw new MemberIdNotSentException("memberId가 전송되지 않았습니다.");
+        }
+
         return memberRepository.findById(memberId)
                 .orElseThrow(() -> {
                     throw new MemberNotFoundException("회원을 찾지 못하였습니다.");

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/service/SchoolService.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/service/SchoolService.java
@@ -3,6 +3,8 @@ package ProjectDoge.StudentSoup.service;
 import ProjectDoge.StudentSoup.dto.school.SchoolFormDto;
 import ProjectDoge.StudentSoup.dto.school.SchoolSearch;
 import ProjectDoge.StudentSoup.entity.school.School;
+import ProjectDoge.StudentSoup.exception.member.MemberIdNotSentException;
+import ProjectDoge.StudentSoup.exception.school.SchoolIdNotSentException;
 import ProjectDoge.StudentSoup.exception.school.SchoolNotFoundException;
 import ProjectDoge.StudentSoup.exception.school.SchoolValidationException;
 import ProjectDoge.StudentSoup.repository.school.SchoolRepository;
@@ -42,11 +44,18 @@ public class SchoolService {
     }
 
     public School findOne(Long schoolId){
-        Optional<School> school = schoolRepository.findById(schoolId);
-        return school.orElseThrow(() -> {
+        checkSchoolIdSent(schoolId);
+
+        return schoolRepository.findById(schoolId).orElseThrow(() -> {
             log.info("findOne 메소드가 실행되었습니다. [{}]", schoolId);
             throw new SchoolNotFoundException("학교를 찾지 못하였습니다.");
         });
+    }
+    private void checkSchoolIdSent(Long schoolId) {
+        if(schoolId == null){
+            log.info("schoolId가 전송되지 않았습니다.");
+            throw new SchoolIdNotSentException("schoolId가 전송되지 않았습니다.");
+        }
     }
 
     public List<School> findAll(){


### PR DESCRIPTION
## 1. Changes
- 회원 프로필 이미지를 업데이트하는 로직을 추가하였습니다.
- 회원 기본키 아이디로 회원 탐색 시 기본키가 전달되지 않는 오류를 추가하였습니다.
- findOne 관련 예외추가 하였습니다.
- 학교 관련 예외 응답 추가하였습니다.

## 2. Screenshot

-
![Image](https://user-images.githubusercontent.com/74203371/210060177-68bae026-b1c0-4dae-9934-8b1bd428f7ff.png)
---
![Image](https://user-images.githubusercontent.com/74203371/210060683-965bbdf0-70e2-421e-878c-f0d7b446f9c6.png)


## 3. Issues

1. 제가 요청 메시지를 잘 못 보내면서 회원의 기본키를 받지 못하는 경우가 있었는데, 그럴 경우 회원을 찾을 때 기본키가 null이면 안되므로, 서버에서 오류가 발생한 것으로 나타납니다. 따라서, 모든 테이블들을 find 할 때 기본적으로 기본키가 null이면 해당 예외를 클라이언트에서 값을 잘 못 보낸 것으로 처리해야 될 것 같습니다.
2. 추가적으로 MultipartFile과 memberId를 동시에 받는 DTO를 만들어서 @ModelAttribute로 데이터를 받아보려고 하였으나, memberId를 받아오지 못하는 것을 발견하였습니다. multipart/form-data 같은 경우는 @RequestPart로 받아올 수 있는데, 이때, 각 part에는 객체로 넘어오기 때문에 @Multipart Long memberId 도 받을 수 없었습니다. -> 단일 값이라서 안되는 것 같습니다.
3. 따라서 @RequestBody로 전달되는 데이터를 @RequestParam으로 전달 받아봤는데 정상적으로 받아올 수 있음을 확인할 수 있었습니다.
4. 아마 @RequestBody로도 받을 수 있을 것 같은데, 다음 회원 정보 수정을 하는 과정에 있어서 @RequestBody로도 받을 수 있으면 통일성을 위해서 @RequestBody로 바꾸겠습니다.
5. PR 올리면서 확인했는데 memberId 못 받아 올 경우 로직에 대해서 리팩토링해서 간단하게 하겠습니다. 
 

## 4. To Reviewer

- multipart/form-data는 너무나 어려운것...

## 5. Plans
- [ ] - 회원 정보를 수정하는 서비스 추가
- [x] - 모든 테이블 findOne 서비스 로직 시 id 못 받는 예외 추가
