### PR TITLE
Mjw/memberUpdateController

### DIFF
--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/controller/member/MemberUpdateController.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/controller/member/MemberUpdateController.java
@@ -1,0 +1,28 @@
+package ProjectDoge.StudentSoup.controller.member;
+
+import ProjectDoge.StudentSoup.dto.member.MemberFormADto;
+import ProjectDoge.StudentSoup.dto.member.MemberUpdateValidationDto;
+import ProjectDoge.StudentSoup.entity.member.Member;
+import ProjectDoge.StudentSoup.service.MemberService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/members")
+public class MemberUpdateController {
+
+    private final MemberService memberService;
+
+    @PostMapping("/edit/{memberId}/validation")
+    public String editIdCheck(@PathVariable("memberId") Long memberId, @Validated @RequestBody MemberUpdateValidationDto dto, BindingResult bindingResult){
+        Member member = memberService.findOne(dto.getMemberId());
+        memberService.validationCoincideMemberIdPwd(member, dto.getPwd());
+
+        return "ok";
+    }
+}

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/controller/member/MemberUpdateController.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/controller/member/MemberUpdateController.java
@@ -19,7 +19,9 @@ public class MemberUpdateController {
     private final MemberService memberService;
 
     @PostMapping("/edit/{memberId}/validation")
-    public String editIdCheck(@PathVariable("memberId") Long memberId, @Validated @RequestBody MemberUpdateValidationDto dto, BindingResult bindingResult){
+    public String editIdCheck(@PathVariable("memberId") Long memberId,
+                              @Validated @RequestBody MemberUpdateValidationDto dto,
+                              BindingResult bindingResult){
         Member member = memberService.findOne(dto.getMemberId());
         memberService.validationCoincideMemberIdPwd(member, dto.getPwd());
 

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/controller/member/MemberUpdateController.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/controller/member/MemberUpdateController.java
@@ -1,6 +1,7 @@
 package ProjectDoge.StudentSoup.controller.member;
 
-import ProjectDoge.StudentSoup.dto.member.MemberFormADto;
+import ProjectDoge.StudentSoup.dto.member.MemberDto;
+import ProjectDoge.StudentSoup.dto.member.MemberUpdateDto;
 import ProjectDoge.StudentSoup.dto.member.MemberUpdateValidationDto;
 import ProjectDoge.StudentSoup.entity.member.Member;
 import ProjectDoge.StudentSoup.service.MemberService;
@@ -27,4 +28,14 @@ public class MemberUpdateController {
 
         return "ok";
     }
+
+    @PostMapping("/edit/{memberId}")
+    public MemberDto editMember(@PathVariable("memberId") Long memberId,
+                                @RequestBody MemberUpdateDto dto){
+        Long updatedMemberId = memberService.updateMember(dto);
+        Member member = memberService.findOne(updatedMemberId);
+        MemberDto memberDto = new MemberDto().getMemberDto(member);
+        return memberDto;
+    }
+
 }

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/dto/admin/AdminMemberUpdateForm.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/dto/admin/AdminMemberUpdateForm.java
@@ -1,5 +1,6 @@
 package ProjectDoge.StudentSoup.dto.admin;
 
+import ProjectDoge.StudentSoup.dto.member.MemberUpdateDto;
 import ProjectDoge.StudentSoup.entity.member.Member;
 import lombok.Getter;
 import lombok.Setter;
@@ -9,7 +10,7 @@ import org.springframework.web.multipart.MultipartFile;
 @Getter
 @Setter
 @ToString
-public class AdminMemberUpdateForm {
+public class AdminMemberUpdateForm extends MemberUpdateDto {
     private Long memberId;
     private Long schoolId;
     private String schoolName;

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/dto/member/MemberUpdateDto.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/dto/member/MemberUpdateDto.java
@@ -1,0 +1,19 @@
+package ProjectDoge.StudentSoup.dto.member;
+
+import lombok.Data;
+
+@Data
+public class MemberUpdateDto {
+    private Long memberId;
+    private Long schoolId;
+    private String schoolName;
+    private Long departmentId;
+    private String departmentName;
+    private String id;
+    private String pwd;
+    private String nickname;
+    private String email;
+
+    //== 생성 메서드 ==//
+    public MemberUpdateDto(){}
+}

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/dto/member/MemberUpdateValidationDto.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/dto/member/MemberUpdateValidationDto.java
@@ -1,0 +1,10 @@
+package ProjectDoge.StudentSoup.dto.member;
+
+import lombok.Data;
+
+@Data
+public class MemberUpdateValidationDto {
+    private Long memberId;
+    private String id;
+    private String pwd;
+}

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/exhandler/advice/MemberAdvice.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/exhandler/advice/MemberAdvice.java
@@ -2,6 +2,7 @@ package ProjectDoge.StudentSoup.exhandler.advice;
 
 import ProjectDoge.StudentSoup.exception.member.MemberIdNotSentException;
 import ProjectDoge.StudentSoup.exception.member.MemberNotFoundException;
+import ProjectDoge.StudentSoup.exception.member.MemberNotSamePassword;
 import ProjectDoge.StudentSoup.exception.member.MemberValidationException;
 import ProjectDoge.StudentSoup.exhandler.ErrorResult;
 import lombok.extern.slf4j.Slf4j;
@@ -23,6 +24,13 @@ public class MemberAdvice {
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     @ExceptionHandler(MemberValidationException.class)
     public ErrorResult memberValidationHandler(MemberValidationException e){
+        log.error("[exceptionHandle] ex", e);
+        return new ErrorResult("MemberValidation", e.getMessage());
+    }
+
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @ExceptionHandler(MemberNotSamePassword.class)
+    public ErrorResult memberCheckPasswordHandler(MemberNotSamePassword e){
         log.error("[exceptionHandle] ex", e);
         return new ErrorResult("MemberValidation", e.getMessage());
     }

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/exhandler/advice/MemberAdvice.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/exhandler/advice/MemberAdvice.java
@@ -32,7 +32,7 @@ public class MemberAdvice {
     @ExceptionHandler(MemberNotSamePassword.class)
     public ErrorResult memberCheckPasswordHandler(MemberNotSamePassword e){
         log.error("[exceptionHandle] ex", e);
-        return new ErrorResult("MemberValidation", e.getMessage());
+        return new ErrorResult("MemberNotSamePassword", e.getMessage());
     }
 
     @ResponseStatus(HttpStatus.BAD_REQUEST)

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/service/MemberService.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/service/MemberService.java
@@ -128,7 +128,7 @@ public class MemberService {
         return member;
     }
 
-    private void validationCoincideMemberIdPwd(Member member, String pwd) {
+    public void validationCoincideMemberIdPwd(Member member, String pwd) {
         log.info("아이디와 비밀번호를 체크하는 검증 로직 실행, 아이디 : [{}], 비밀번호 : [{}]", member.getId(), pwd);
         if(notSameMemberIdPwd(member, pwd)) {
             log.info("아이디와 패스워드가 일치하지 않는 예외 발생");


### PR DESCRIPTION
## 1. Changes
- 회원 정보 수정 시 비밀번호를 검증하는 api를 추가하였습니다.
- 아이디, 패스워드가 일치하지 않을 때 예외를 처리하는 응답 코드를 추가하였습니다.
---
- 회원 정보 수정 서비스 로직을 추가하였습니다.
- 회원 정보 수정 api를 추가하였습니다.

## 2. Screenshot

- ![Image](https://user-images.githubusercontent.com/74203371/210160682-7e0b8dd6-8da8-461a-af74-c99ce9e2b36c.png)
- ![Image](https://user-images.githubusercontent.com/74203371/210161341-78a46f7e-2133-4a50-84e5-acfa7d9ee08d.png)
- ![Image](https://user-images.githubusercontent.com/74203371/210161365-d62cb6fe-f642-4949-a69e-31a8ec7768e0.png)


## 3. Issues

1. 
2. 

## 4. To Reviewer

- 회원 정보를 수정할 때, 학교랑 학과를 불러오는 api 회원가입 때 사용했던 걸 재 사용해야 하는 문제점이 있었습니다. 그 때 해당 api 이름을 /members/signUp/3, /members/signUp/3/{schoolId} 로 작성해두었었는데, 이걸 재사용 해야 하더라구요.
이렇게 재사용 될 것 같은 건 api 이름을 어떻게 하는 게 좋을까요? 좋은 의견 주세요!
ex) /members/schools, /members/{schoolId}/departments ..?

## 5. Plans
- [x] - 회원 정보 수정 서비스 로직 작성
- [ ] - 
