### PR TITLE
- mjw/refactorSignUpResult

### DIFF
--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/controller/member/SignupController.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/controller/member/SignupController.java
@@ -15,9 +15,13 @@ import ProjectDoge.StudentSoup.service.member.MemberValidationService;
 import ProjectDoge.StudentSoup.service.school.SchoolFindService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.Hashtable;
 import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
 @Slf4j
@@ -64,11 +68,13 @@ public class SignupController {
     }
 
     @PostMapping("/signUp/3")
-    public String signUp(@RequestBody MemberFormBDto dto){
+    public ResponseEntity<ConcurrentHashMap<String, String>> signUp(@RequestBody MemberFormBDto dto){
         log.info("signUp 메소드가 실행되었습니다. schoolId : [{}], departmentId : [{}]", dto.getSchoolId(), dto.getDepartmentId());
         Long memberId = memberRegisterService.join(dto);
         Member member = memberFindService.findOne(memberId);
-        log.info("member의 성별 : [{}]", member.getGender());
-        return "ok";
+        log.info("member 의 성별 : [{}]", member.getGender());
+        ConcurrentHashMap<String, String> result = new ConcurrentHashMap<>();
+        result.put("result", "ok");
+        return ResponseEntity.ok(result);
     }
 }

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/controller/member/SignupController.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/controller/member/SignupController.java
@@ -64,12 +64,11 @@ public class SignupController {
     }
 
     @PostMapping("/signUp/3")
-    public MemberDto signUp(@RequestBody MemberFormBDto dto){
+    public String signUp(@RequestBody MemberFormBDto dto){
         log.info("signUp 메소드가 실행되었습니다. schoolId : [{}], departmentId : [{}]", dto.getSchoolId(), dto.getDepartmentId());
         Long memberId = memberRegisterService.join(dto);
         Member member = memberFindService.findOne(memberId);
         log.info("member의 성별 : [{}]", member.getGender());
-        MemberDto result = new MemberDto().getMemberDto(member);
-        return result;
+        return "ok";
     }
 }


### PR DESCRIPTION
## 1. Changes

1. 회원가입 성공 시 보내는 리턴타입을 객체타입(Json) 에서 plainText로 ok만 보내는 것으로 수정하였습니다.

## 2. Screenshot
1. 변환 전
![image](https://user-images.githubusercontent.com/74203371/211256056-14352622-ff2b-49d1-b540-e37ac56e0b7b.png)
---
2. 변환 후
![image](https://user-images.githubusercontent.com/74203371/211255794-627dd83c-00e5-476b-918f-a759b88291e3.png)

## 3. Issues

1. 회원가입 시에는 회원가입에 성공한 회원의 `DTO` _(정보라고 보시면 됩니다.)_  를 보내주기보다는 성공메시지만 보내고, 로그인을 해야 DTO를 보내주는 방식으로 수정할까해서 수정을 하게 되었습니다. 
2. 한 가지 의문이 있습니다.
성공메시지를 `"ok"` 를 보내주는데 이럴 경우 `Content-type`이 `application/json` 이 아니고, `plain/text` 로 날라가게 됩니다.


## 4. To Reviewer

@inclined37 @yeeeerim @esk147 
1. 에러코드같은경우는 `application/json`으로 날라가게 되는데, `error`의 `content-type`과 `response`의 `content-type`을 프론트엔드 단에서 따로 동적으로 바꿀 수 가 있는 건지는 의문입니다.
2. 만약 안된다면, `application/json` 으로 `"result" : "ok"` 로 넘겨드리겠습니다.

## 5. Plans

