### PR TITLE
Kth/create board call service

### DIFF
--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/controller/board/BoardCallController.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/controller/board/BoardCallController.java
@@ -1,12 +1,12 @@
 package ProjectDoge.StudentSoup.controller.board;
 
+import ProjectDoge.StudentSoup.dto.board.BoardDto;
 import ProjectDoge.StudentSoup.dto.board.BoardMainDto;
+import ProjectDoge.StudentSoup.entity.board.Board;
 import ProjectDoge.StudentSoup.service.board.BoardCallService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 import java.util.Map;
@@ -23,4 +23,8 @@ public class BoardCallController {
         return  boardCallService.getBoardInSchool(map.get("schoolId"),map.get("memberId"));
     }
 
+    @PostMapping("/board/{boardId}/{memberId}")
+    public BoardDto clickBoard(@PathVariable Long boardId,@PathVariable Long memberId){
+        return  boardCallService.getBoardDetail(boardId,memberId);
+    }
 }

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/controller/board/BoardCallController.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/controller/board/BoardCallController.java
@@ -1,0 +1,26 @@
+package ProjectDoge.StudentSoup.controller.board;
+
+import ProjectDoge.StudentSoup.dto.board.BoardMainDto;
+import ProjectDoge.StudentSoup.service.board.BoardCallService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+import java.util.Map;
+
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+public class BoardCallController {
+    private final BoardCallService boardCallService;
+
+    @GetMapping("/boards")
+    public List<BoardMainDto> firstCallBoard(@RequestBody Map<String,Long> map){
+        return  boardCallService.getBoardInSchool(map.get("schoolId"),map.get("memberId"));
+    }
+
+}

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/dto/board/BoardDto.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/dto/board/BoardDto.java
@@ -5,27 +5,22 @@ import ProjectDoge.StudentSoup.entity.board.BoardCategory;
 import ProjectDoge.StudentSoup.entity.board.BoardLike;
 import ProjectDoge.StudentSoup.entity.board.BoardReview;
 import ProjectDoge.StudentSoup.entity.file.ImageFile;
-import ProjectDoge.StudentSoup.entity.member.Member;
-import ProjectDoge.StudentSoup.entity.school.Department;
-import ProjectDoge.StudentSoup.entity.school.School;
+import lombok.Getter;
+import lombok.Setter;
 
-import javax.persistence.*;
+
 import java.util.ArrayList;
 import java.util.List;
 
+@Getter
+@Setter
 public class BoardDto {
 
     private Long id;
 
-    private School school;
-
-    private Department department;
-
     private BoardCategory boardCategory;
 
     private String title;
-
-    private Member member;
 
     private String content;
 
@@ -48,11 +43,8 @@ public class BoardDto {
     private boolean like;
     public BoardDto(Board board,Boolean like) {
         this.id = board.getId();
-        this.school = board.getSchool();
-        this.department = board.getDepartment();
         this.boardCategory = board.getBoardCategory();
         this.title = board.getTitle();
-        this.member = board.getMember();
         this.content = board.getContent();
         this.ip = board.getIp();
         if(board.getImageFile() == null){

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/dto/board/BoardDto.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/dto/board/BoardDto.java
@@ -1,0 +1,72 @@
+package ProjectDoge.StudentSoup.dto.board;
+
+import ProjectDoge.StudentSoup.entity.board.Board;
+import ProjectDoge.StudentSoup.entity.board.BoardCategory;
+import ProjectDoge.StudentSoup.entity.board.BoardLike;
+import ProjectDoge.StudentSoup.entity.board.BoardReview;
+import ProjectDoge.StudentSoup.entity.file.ImageFile;
+import ProjectDoge.StudentSoup.entity.member.Member;
+import ProjectDoge.StudentSoup.entity.school.Department;
+import ProjectDoge.StudentSoup.entity.school.School;
+
+import javax.persistence.*;
+import java.util.ArrayList;
+import java.util.List;
+
+public class BoardDto {
+
+    private Long id;
+
+    private School school;
+
+    private Department department;
+
+    private BoardCategory boardCategory;
+
+    private String title;
+
+    private Member member;
+
+    private String content;
+
+    private String ip;
+
+    private ImageFile imageFile;
+
+    private int view;
+
+    private String writeDate;
+
+    private String updateDate;
+
+    private int likedCount;
+
+    private List<BoardReview> boardReviews = new ArrayList<>();
+
+    private List<BoardLike> boardLikes = new ArrayList<>();
+
+    private boolean like;
+    public BoardDto(Board board,Boolean like) {
+        this.id = board.getId();
+        this.school = board.getSchool();
+        this.department = board.getDepartment();
+        this.boardCategory = board.getBoardCategory();
+        this.title = board.getTitle();
+        this.member = board.getMember();
+        this.content = board.getContent();
+        this.ip = board.getIp();
+        if(board.getImageFile() == null){
+            this.imageFile = null;
+        }
+        else{
+            this.imageFile = board.getImageFile();
+        }
+        this.view = board.getView();
+        this.writeDate = board.getWriteDate();
+        this.updateDate = board.getUpdateDate();
+        this.likedCount = board.getLikedCount();
+        this.boardReviews = board.getBoardReviews();
+        this.boardLikes = board.getBoardLikes();
+        this.like = like;
+    }
+}

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/dto/board/BoardFormDto.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/dto/board/BoardFormDto.java
@@ -21,4 +21,10 @@ public class BoardFormDto {
         this.setContent(board.getContent());
         this.setImageFile(board.getImageFile());
     }
+    public BoardFormDto createBoardFormDto(String title,BoardCategory category,String content){
+        this.title = title;
+        this.boardCategory = category;
+        this.content = content;
+        return this;
+    }
 }

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/dto/board/BoardMainDto.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/dto/board/BoardMainDto.java
@@ -1,6 +1,7 @@
 package ProjectDoge.StudentSoup.dto.board;
 
 import ProjectDoge.StudentSoup.entity.board.BoardCategory;
+import com.querydsl.core.annotations.QueryProjection;
 import lombok.Getter;
 import lombok.Setter;
 

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/dto/board/BoardMainDto.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/dto/board/BoardMainDto.java
@@ -1,0 +1,27 @@
+package ProjectDoge.StudentSoup.dto.board;
+
+import ProjectDoge.StudentSoup.entity.board.BoardCategory;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class BoardMainDto {
+    private Long boardId;
+
+    private BoardCategory boardCategory;
+
+    private String title;
+
+    private String updateDate;
+
+    private int likedCount;
+
+    public BoardMainDto(Long boardId, BoardCategory boardCategory, String title, String updateDate, int likedCount) {
+        this.boardId = boardId;
+        this.boardCategory = boardCategory;
+        this.title = title;
+        this.updateDate = updateDate;
+        this.likedCount = likedCount;
+    }
+}

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/dto/board/BoardMainDto.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/dto/board/BoardMainDto.java
@@ -1,5 +1,6 @@
 package ProjectDoge.StudentSoup.dto.board;
 
+import ProjectDoge.StudentSoup.entity.board.Board;
 import ProjectDoge.StudentSoup.entity.board.BoardCategory;
 import com.querydsl.core.annotations.QueryProjection;
 import lombok.Getter;
@@ -18,11 +19,11 @@ public class BoardMainDto {
 
     private int likedCount;
 
-    public BoardMainDto(Long boardId, BoardCategory boardCategory, String title, String updateDate, int likedCount) {
-        this.boardId = boardId;
-        this.boardCategory = boardCategory;
-        this.title = title;
-        this.updateDate = updateDate;
-        this.likedCount = likedCount;
+    public BoardMainDto(Board board) {
+        this.boardId = board.getId();
+        this.boardCategory = board.getBoardCategory();
+        this.title = board.getTitle();
+        this.updateDate = board.getUpdateDate();
+        this.likedCount = board.getLikedCount();
     }
 }

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/init/TestDataInit.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/init/TestDataInit.java
@@ -1,17 +1,23 @@
 package ProjectDoge.StudentSoup.init;
 
+import ProjectDoge.StudentSoup.dto.board.BoardFormDto;
 import ProjectDoge.StudentSoup.dto.department.DepartmentFormDto;
 import ProjectDoge.StudentSoup.dto.member.MemberFormBDto;
 import ProjectDoge.StudentSoup.dto.restaurant.RestaurantFormDto;
 import ProjectDoge.StudentSoup.dto.school.SchoolFormDto;
+import ProjectDoge.StudentSoup.entity.board.BoardCategory;
 import ProjectDoge.StudentSoup.entity.file.ImageFile;
 import ProjectDoge.StudentSoup.entity.member.GenderType;
+import ProjectDoge.StudentSoup.entity.member.Member;
 import ProjectDoge.StudentSoup.entity.restaurant.RestaurantCategory;
 import ProjectDoge.StudentSoup.entity.school.Department;
 import ProjectDoge.StudentSoup.entity.school.School;
 import ProjectDoge.StudentSoup.repository.department.DepartmentRepository;
+import ProjectDoge.StudentSoup.repository.member.MemberRepository;
 import ProjectDoge.StudentSoup.repository.school.SchoolRepository;
+import ProjectDoge.StudentSoup.service.board.BoardResisterService;
 import ProjectDoge.StudentSoup.service.department.DepartmentRegisterService;
+import ProjectDoge.StudentSoup.service.member.MemberFindService;
 import ProjectDoge.StudentSoup.service.member.MemberRegisterService;
 import ProjectDoge.StudentSoup.service.restaurant.RestaurantRegisterService;
 import ProjectDoge.StudentSoup.service.school.SchoolRegisterService;
@@ -23,6 +29,7 @@ import org.springframework.stereotype.Component;
 
 import java.time.LocalTime;
 import java.util.List;
+import java.util.Optional;
 
 @Component
 @Profile("local")
@@ -35,11 +42,16 @@ public class TestDataInit {
     private final DepartmentRegisterService departmentRegisterService;
     private final RestaurantRegisterService restaurantRegisterService;
 
+    private final BoardResisterService boardResisterService;
+
+    private  final MemberRepository memberRepository;
+
     @EventListener(ApplicationReadyEvent.class)
     public void init(){
         initSchoolAndDepartment();
         initMember();
         initRestaurant();
+        initBoard();
     }
 
     private void initSchoolAndDepartment(){
@@ -141,6 +153,17 @@ public class TestDataInit {
                 "디테일");
         restaurantRegisterService.join(dto);
         restaurantRegisterService.join(dto2);
+    }
+    private void initBoard(){
+        Member member = memberRepository.findByIdAndPwd("dummyTest1", "test123!").get();
+        Member member1 = memberRepository.findByIdAndPwd("dummyTest2", "test123!").get();
+
+
+        BoardFormDto dto = new BoardFormDto().createBoardFormDto("테스트 제목", BoardCategory.FREE,"테스트 내용");
+        BoardFormDto dto2 = new BoardFormDto().createBoardFormDto("테스트 제목2", BoardCategory.CONSULTING,"테스트 내용2");
+        boardResisterService.join(member.getMemberId(),dto);
+        boardResisterService.join(member1.getMemberId(),dto2);
+
     }
 
     private MemberFormBDto createMemberFormDto(String id, String pwd, String nickname, String email,

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/repository/board/BoardLikeRepository.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/repository/board/BoardLikeRepository.java
@@ -1,0 +1,8 @@
+package ProjectDoge.StudentSoup.repository.board;
+
+import ProjectDoge.StudentSoup.entity.board.BoardLike;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface BoardLikeRepository extends JpaRepository<BoardLike,Long>,BoardLikeRepositoryCustom {
+
+}

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/repository/board/BoardLikeRepositoryCustom.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/repository/board/BoardLikeRepositoryCustom.java
@@ -1,0 +1,10 @@
+package ProjectDoge.StudentSoup.repository.board;
+
+import ProjectDoge.StudentSoup.entity.board.BoardLike;
+
+import java.util.Optional;
+
+public interface BoardLikeRepositoryCustom {
+
+    Optional<BoardLike> findByBoardIdAndMemberId(Long boardId, Long MemberId);
+}

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/repository/board/BoardLikeRepositoryImpl.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/repository/board/BoardLikeRepositoryImpl.java
@@ -1,0 +1,27 @@
+package ProjectDoge.StudentSoup.repository.board;
+
+import ProjectDoge.StudentSoup.entity.board.BoardLike;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+
+import java.util.Optional;
+
+import static ProjectDoge.StudentSoup.entity.board.QBoard.board;
+import static ProjectDoge.StudentSoup.entity.board.QBoardLike.boardLike;
+import static ProjectDoge.StudentSoup.entity.member.QMember.member;
+
+@RequiredArgsConstructor
+public class BoardLikeRepositoryImpl implements BoardLikeRepositoryCustom{
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Optional<BoardLike> findByBoardIdAndMemberId(Long boardId, Long memberId){
+        BoardLike query = queryFactory.
+                select(boardLike)
+                .from(boardLike)
+                .where(boardLike.board.id.eq(boardId),boardLike.member.memberId.eq(memberId))
+                .fetchOne();
+        return Optional.ofNullable(query);
+    }
+}

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/repository/board/BoardRepositoryCustom.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/repository/board/BoardRepositoryCustom.java
@@ -1,10 +1,11 @@
 package ProjectDoge.StudentSoup.repository.board;
 
 import ProjectDoge.StudentSoup.dto.board.BoardMainDto;
+import ProjectDoge.StudentSoup.entity.board.Board;
 
 import java.util.List;
 
 public interface BoardRepositoryCustom {
 
-    List<BoardMainDto> findBySchoolId(Long schoolId);
+    List<Board> findBySchoolId(Long schoolId);
 }

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/repository/board/BoardRepositoryCustom.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/repository/board/BoardRepositoryCustom.java
@@ -1,5 +1,10 @@
 package ProjectDoge.StudentSoup.repository.board;
 
+import ProjectDoge.StudentSoup.dto.board.BoardMainDto;
+
+import java.util.List;
+
 public interface BoardRepositoryCustom {
 
+    List<BoardMainDto> findBySchoolId(Long schoolId);
 }

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/repository/board/BoardRepositoryImpl.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/repository/board/BoardRepositoryImpl.java
@@ -1,5 +1,33 @@
 package ProjectDoge.StudentSoup.repository.board;
 
-public class BoardRepositoryImpl implements BoardRepositoryCustom {
 
+import ProjectDoge.StudentSoup.dto.board.BoardMainDto;
+import ProjectDoge.StudentSoup.entity.board.QBoard;
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+
+import java.util.List;
+
+import static ProjectDoge.StudentSoup.entity.board.QBoard.board;
+import static ProjectDoge.StudentSoup.entity.school.QSchool.school;
+
+@RequiredArgsConstructor
+public class BoardRepositoryImpl implements BoardRepositoryCustom {
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<BoardMainDto> findBySchoolId(Long schoolId){
+        List<BoardMainDto> query= queryFactory.
+                select(Projections.bean(BoardMainDto.class, board.id,
+                        board.boardCategory,
+                        board.title,
+                        board.updateDate,
+                        board.likedCount))
+                .leftJoin(board.school,school)
+                .fetchJoin()
+                .where(board.school.id.eq(schoolId))
+                .fetch();
+    return query;
+    }
 }

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/repository/board/BoardRepositoryImpl.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/repository/board/BoardRepositoryImpl.java
@@ -2,6 +2,8 @@ package ProjectDoge.StudentSoup.repository.board;
 
 
 import ProjectDoge.StudentSoup.dto.board.BoardMainDto;
+import ProjectDoge.StudentSoup.dto.board.QBoardMainDto;
+import ProjectDoge.StudentSoup.entity.board.Board;
 import ProjectDoge.StudentSoup.entity.board.QBoard;
 import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -17,17 +19,15 @@ public class BoardRepositoryImpl implements BoardRepositoryCustom {
     private final JPAQueryFactory queryFactory;
 
     @Override
-    public List<BoardMainDto> findBySchoolId(Long schoolId){
-        List<BoardMainDto> query= queryFactory.
-                select(Projections.bean(BoardMainDto.class, board.id,
-                        board.boardCategory,
-                        board.title,
-                        board.updateDate,
-                        board.likedCount))
+    public List<Board> findBySchoolId(Long schoolId){
+        List<Board> query= queryFactory.
+                select(board)
+                .from(board)
                 .leftJoin(board.school,school)
                 .fetchJoin()
                 .where(board.school.id.eq(schoolId))
                 .fetch();
+
     return query;
     }
 }

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/service/board/BoardCallService.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/service/board/BoardCallService.java
@@ -1,12 +1,14 @@
 package ProjectDoge.StudentSoup.service.board;
 
 import ProjectDoge.StudentSoup.dto.board.BoardMainDto;
+import ProjectDoge.StudentSoup.entity.board.Board;
 import ProjectDoge.StudentSoup.exception.member.MemberIdNotSentException;
 import ProjectDoge.StudentSoup.repository.board.BoardRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @Slf4j
@@ -19,8 +21,11 @@ public class BoardCallService {
 
     public List<BoardMainDto> getBoardInSchool(Long schoolId,Long memberId){
         if(memberId == null) throw new MemberIdNotSentException("맴버 아이디가 전송되지 않았습니다.");
-
-        List<BoardMainDto> boardMainDtoList = boardRepository.findBySchoolId(schoolId);
+        List<BoardMainDto> boardMainDtoList = new ArrayList<>();
+        List<Board> boards = boardRepository.findBySchoolId(schoolId);
+        for(Board board : boards){
+            boardMainDtoList.add(new BoardMainDto(board.getId(),board.getBoardCategory(),board.getTitle(),board.getUpdateDate(),board.getLikedCount()));
+        }
         return boardMainDtoList;
     }
 

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/service/board/BoardCallService.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/service/board/BoardCallService.java
@@ -1,0 +1,27 @@
+package ProjectDoge.StudentSoup.service.board;
+
+import ProjectDoge.StudentSoup.dto.board.BoardMainDto;
+import ProjectDoge.StudentSoup.exception.member.MemberIdNotSentException;
+import ProjectDoge.StudentSoup.repository.board.BoardRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class BoardCallService {
+    private final BoardFindService boardFindService;
+
+    private final BoardRepository boardRepository;
+
+    public List<BoardMainDto> getBoardInSchool(Long schoolId,Long memberId){
+        if(memberId == null) throw new MemberIdNotSentException("맴버 아이디가 전송되지 않았습니다.");
+
+        List<BoardMainDto> boardMainDtoList = boardRepository.findBySchoolId(schoolId);
+        return boardMainDtoList;
+    }
+
+}

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/service/board/BoardCallService.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/service/board/BoardCallService.java
@@ -5,6 +5,7 @@ import ProjectDoge.StudentSoup.dto.board.BoardMainDto;
 import ProjectDoge.StudentSoup.entity.board.Board;
 import ProjectDoge.StudentSoup.entity.board.BoardLike;
 import ProjectDoge.StudentSoup.exception.member.MemberIdNotSentException;
+import ProjectDoge.StudentSoup.exception.member.MemberNotFoundException;
 import ProjectDoge.StudentSoup.repository.board.BoardLikeRepository;
 import ProjectDoge.StudentSoup.repository.board.BoardRepository;
 import lombok.RequiredArgsConstructor;
@@ -26,7 +27,8 @@ public class BoardCallService {
     boolean boardNotLiked = false;
 
     public List<BoardMainDto> getBoardInSchool(Long schoolId,Long memberId){
-        if(memberId == null) throw new MemberIdNotSentException("맴버 아이디가 전송되지 않았습니다.");
+        log.info("게시판 클릭시 게시글 호출 로직이 실행되었습니다.");
+        isLoginMember(memberId);
         List<BoardMainDto> boardMainDtoList = new ArrayList<>();
         List<Board> boards = boardRepository.findBySchoolId(schoolId);
         for(Board board : boards){
@@ -36,6 +38,7 @@ public class BoardCallService {
     }
 
     public BoardDto getBoardDetail(Long boardId,Long memberId){
+        log.info("게시글 클릭시 게시글 호출 로직이 실행되었습니다.");
         Board board = boardFindService.findOne(boardId);
         BoardLike boardLike = boardLikeRepository.findByBoardIdAndMemberId(boardId, memberId).orElse(null);
         if(boardLike==null){
@@ -44,6 +47,15 @@ public class BoardCallService {
         return getLikeBoardDto(board);
 
     }
+    private void isLoginMember(Long memberId){
+        log.info("회원이 로그인이 되었는지 확인하는 로직이 실행되었습니다.");
+        if(memberId == null){
+            log.info("회원의 기본키가 전달이 되지 않았거나 로그인이 되어있지 않은 상태입니다.");
+            throw new MemberNotFoundException("회원이 로그인이 되어있지 않은 상태이거나, 기본키가 전달 되지 않았습니다.");
+        }
+        log.info("회원이 로그인이 되어있는 상태입니다.");
+    }
+
     private BoardDto getLikeBoardDto(Board board) {
         return new BoardDto(board,boardLiked);
     }

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/service/board/BoardCallService.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/service/board/BoardCallService.java
@@ -1,8 +1,11 @@
 package ProjectDoge.StudentSoup.service.board;
 
+import ProjectDoge.StudentSoup.dto.board.BoardDto;
 import ProjectDoge.StudentSoup.dto.board.BoardMainDto;
 import ProjectDoge.StudentSoup.entity.board.Board;
+import ProjectDoge.StudentSoup.entity.board.BoardLike;
 import ProjectDoge.StudentSoup.exception.member.MemberIdNotSentException;
+import ProjectDoge.StudentSoup.repository.board.BoardLikeRepository;
 import ProjectDoge.StudentSoup.repository.board.BoardRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -10,23 +13,43 @@ import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class BoardCallService {
     private final BoardFindService boardFindService;
-
     private final BoardRepository boardRepository;
+    private  final BoardLikeRepository boardLikeRepository;
+    boolean boardLiked =true;
+    boolean boardNotLiked = false;
 
     public List<BoardMainDto> getBoardInSchool(Long schoolId,Long memberId){
         if(memberId == null) throw new MemberIdNotSentException("맴버 아이디가 전송되지 않았습니다.");
         List<BoardMainDto> boardMainDtoList = new ArrayList<>();
         List<Board> boards = boardRepository.findBySchoolId(schoolId);
         for(Board board : boards){
-            boardMainDtoList.add(new BoardMainDto(board.getId(),board.getBoardCategory(),board.getTitle(),board.getUpdateDate(),board.getLikedCount()));
+            boardMainDtoList.add(new BoardMainDto(board));
         }
         return boardMainDtoList;
+    }
+
+    public BoardDto getBoardDetail(Long boardId,Long memberId){
+        Board board = boardFindService.findOne(boardId);
+        BoardLike boardLike = boardLikeRepository.findByBoardIdAndMemberId(boardId, memberId).orElse(null);
+        if(boardLike==null){
+            return getNotLikeBoardDto(board);
+        }
+        return getLikeBoardDto(board);
+
+    }
+    private BoardDto getLikeBoardDto(Board board) {
+        return new BoardDto(board,boardLiked);
+    }
+
+    private BoardDto getNotLikeBoardDto(Board board) {
+        return new BoardDto(board,boardNotLiked);
     }
 
 }

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/service/board/BoardResisterService.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/service/board/BoardResisterService.java
@@ -34,4 +34,14 @@ public class BoardResisterService {
         log.info("게시글이 저장되었습니다.[{}]",board.getId());
         return board.getId();
     }
+
+    @Transactional
+    public  Long join(Long memberId,BoardFormDto boardFormDto){
+        log.info("게시글 생성 메소드가 실행되었습니다");
+        Member member = memberFindService.findOne(memberId);
+        Board board = new Board().createBoard(boardFormDto,member, member.getSchool(),boardFormDto.getImageFile(),member.getDepartment());
+        boardRepository.save(board);
+        log.info("게시글이 저장되었습니다.[{}]",board.getId());
+        return board.getId();
+    }
 }


### PR DESCRIPTION
## 1. Changes

- 게시판 테스트 데이터를 추가했습니다.
- 게시판 클릭 시 게시글 호출 서비스를 추가했습니다.
- 게시글 클릭 시 게시글 호출 서비스를 추가했습니다.
- 게시판 클릭 시 게시글 객체 리스트 호출 컨트롤러 추가했습니다
- 게시글 클릭 시 게시글 객체 호출 컨트롤러 추가했습니다
- 게시판 좋아요 관련 커리 작성을 위해 저장소 추가했습니다.
## 2. Screenshot
- 
![image](https://user-images.githubusercontent.com/50618668/211996540-5dd218bd-3d8d-4fb3-acc4-474599cf654b.png)
![image](https://user-images.githubusercontent.com/50618668/212016701-9354fd5d-fb7d-4391-ae61-2fa42d107fcb.png)
![image](https://user-images.githubusercontent.com/50618668/212016766-7cbd12dc-a2a2-41db-8dcc-6ea01189144d.png)
![image](https://user-images.githubusercontent.com/50618668/211998247-d99771f3-c717-49f0-9dda-5e9408b0fc3c.png)
![image](https://user-images.githubusercontent.com/50618668/211998374-06811d62-6e58-4a10-bb70-9d25b0d2d411.png)
![image](https://user-images.githubusercontent.com/50618668/212016201-2a73c127-1846-4f96-9416-d88bb2f29643.png)
![image](https://user-images.githubusercontent.com/50618668/212016264-219de380-c445-4ead-a86d-4caeec4bdff5.png)



## 3. Issues

1. boardDto를 Json데이터로 변환하는 과정에서 엔티티 연관관계로 인한 에러가 발생했습니다. JPA 연관관계에서 양방향 매핑을 선언한 경우 발생합니다. JSON타입을 변환하는 도중에 엔티티의 필드가 다른 엔티티를 참조하고 그 엔티티의 필드가 다른 엔티티를 참조하는 무한 루프의 경우 발생 된다고 하는합니다. 해결 방법은 @JsonManagedReference, @JsonBackReference 이 있었지만 필요 없는 필드라 생각되어 필드를 삭제하는 방법으로 문제를 해결했습니다.
2. 

## 4. To Reviewer

-

## 5. Plans
- [ ] - 게시글 좋아요 서비스 구현
- [ ] -
