### PR TITLE
Mjw/addrestaurant review count

### DIFF
--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/controller/restaurantreview/RestaurantReviewRegisterController.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/controller/restaurantreview/RestaurantReviewRegisterController.java
@@ -28,6 +28,7 @@ public class RestaurantReviewRegisterController {
 
         ConcurrentHashMap<String, Object> resultMap = new ConcurrentHashMap<>();
         restaurantReviewRegisterService.join(dto);
+        restaurantReviewRegisterService.starUpdate(restaurantId);
         resultMap.put("result", "ok");
 
         return ResponseEntity.ok(resultMap);

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/controller/restaurantreview/RestaurantReviewRegisterController.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/controller/restaurantreview/RestaurantReviewRegisterController.java
@@ -1,6 +1,7 @@
 package ProjectDoge.StudentSoup.controller.restaurantreview;
 
 
+import ProjectDoge.StudentSoup.dto.restaurant.RestaurantReviewRegRespDto;
 import ProjectDoge.StudentSoup.dto.restaurant.RestaurantReviewRequestDto;
 import ProjectDoge.StudentSoup.service.restaurantreview.RestaurantReviewRegisterService;
 import lombok.RequiredArgsConstructor;
@@ -28,7 +29,9 @@ public class RestaurantReviewRegisterController {
 
         ConcurrentHashMap<String, Object> resultMap = new ConcurrentHashMap<>();
         restaurantReviewRegisterService.join(dto);
-        restaurantReviewRegisterService.starUpdate(restaurantId);
+        RestaurantReviewRegRespDto respDto = restaurantReviewRegisterService.starUpdate(restaurantId);
+
+        resultMap.put("data", respDto);
         resultMap.put("result", "ok");
 
         return ResponseEntity.ok(resultMap);

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/dto/restaurant/RestaurantDetailDto.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/dto/restaurant/RestaurantDetailDto.java
@@ -17,7 +17,7 @@ public class RestaurantDetailDto {
     private String distance;
     private String fileName;
     private int reviewCount;
-    private float starLiked;
+    private double starLiked;
     private int likedCount;
     private int viewCount;
     private boolean like;

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/dto/restaurant/RestaurantDto.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/dto/restaurant/RestaurantDto.java
@@ -16,7 +16,7 @@ public class RestaurantDto {
     private LocalTime endTime;
     private String distance;
     private String fileName;
-    private float starLiked;
+    private double starLiked;
     private int likedCount;
     private int viewCount;
     private boolean like;

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/dto/restaurant/RestaurantReviewRegRespDto.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/dto/restaurant/RestaurantReviewRegRespDto.java
@@ -1,0 +1,14 @@
+package ProjectDoge.StudentSoup.dto.restaurant;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+
+public class RestaurantReviewRegRespDto {
+
+    private Long restaurantId;
+    private double starLiked;
+    private Long reviewCount;
+}

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/dto/restaurant/RestaurantReviewRequestDto.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/dto/restaurant/RestaurantReviewRequestDto.java
@@ -12,7 +12,6 @@ public class RestaurantReviewRequestDto {
     private Long memberId;
     private String nickName;
     private String content;
-    private String menuName;
     private int starLiked;
     private List<MultipartFile> multipartFileList;
 }

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/entity/restaurant/Restaurant.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/entity/restaurant/Restaurant.java
@@ -49,7 +49,7 @@ public class Restaurant {
 
     private int viewCount;
 
-    private float starLiked;
+    private double starLiked;
 
     private int likedCount;
 
@@ -171,7 +171,7 @@ public class Restaurant {
     }
 
     // 별점 업데이트 로직
-    public void updateStarLiked(float starLiked){
+    public void updateStarLiked(double starLiked){
         this.starLiked = starLiked;
     }
 

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/entity/restaurant/Restaurant.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/entity/restaurant/Restaurant.java
@@ -156,6 +156,7 @@ public class Restaurant {
         return (rad * 180 / Math.PI);
     }
 
+    // 좋아요 업데이트 로직
     public void addLikedCount(){
         this.likedCount += 1;
     }
@@ -164,8 +165,14 @@ public class Restaurant {
             this.likedCount -= 1;
         }
     }
+    // 조회수 업데이트 로직
     public void addViewCount() {
         this.viewCount += 1;
+    }
+
+    // 별점 업데이트 로직
+    public void updateStarLiked(float starLiked){
+        this.starLiked = starLiked;
     }
 
 }

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/entity/restaurant/RestaurantReview.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/entity/restaurant/RestaurantReview.java
@@ -33,7 +33,6 @@ public class RestaurantReview {
 
     private String content;
 
-    private String menuName;
 
     @OneToMany(mappedBy = "restaurantReview")
     private List<ImageFile> imageFileList = new ArrayList<>();
@@ -69,7 +68,6 @@ public class RestaurantReview {
         this.member = member;
         this.nickname = dto.getNickName();
         this.content = dto.getContent();
-        this.menuName = dto.getMenuName();
         this.likedCount = 0;
         this.starLiked = dto.getStarLiked();
         this.writeDate = LocalDate.now();

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/exception/restaurant/RestaurantReviewContentLessThanFiveException.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/exception/restaurant/RestaurantReviewContentLessThanFiveException.java
@@ -1,0 +1,23 @@
+package ProjectDoge.StudentSoup.exception.restaurant;
+
+public class RestaurantReviewContentLessThanFiveException extends RuntimeException {
+    public RestaurantReviewContentLessThanFiveException() {
+        super();
+    }
+
+    public RestaurantReviewContentLessThanFiveException(String message) {
+        super(message);
+    }
+
+    public RestaurantReviewContentLessThanFiveException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public RestaurantReviewContentLessThanFiveException(Throwable cause) {
+        super(cause);
+    }
+
+    protected RestaurantReviewContentLessThanFiveException(String message, Throwable cause, boolean enableSuppression, boolean writableStackTrace) {
+        super(message, cause, enableSuppression, writableStackTrace);
+    }
+}

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/exception/restaurant/RestaurantStarLikedMoreThanFiveException.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/exception/restaurant/RestaurantStarLikedMoreThanFiveException.java
@@ -1,0 +1,23 @@
+package ProjectDoge.StudentSoup.exception.restaurant;
+
+public class RestaurantStarLikedMoreThanFiveException extends RuntimeException {
+    public RestaurantStarLikedMoreThanFiveException() {
+        super();
+    }
+
+    public RestaurantStarLikedMoreThanFiveException(String message) {
+        super(message);
+    }
+
+    public RestaurantStarLikedMoreThanFiveException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public RestaurantStarLikedMoreThanFiveException(Throwable cause) {
+        super(cause);
+    }
+
+    protected RestaurantStarLikedMoreThanFiveException(String message, Throwable cause, boolean enableSuppression, boolean writableStackTrace) {
+        super(message, cause, enableSuppression, writableStackTrace);
+    }
+}

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/exhandler/advice/RestaurantMenuAdvice.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/exhandler/advice/RestaurantMenuAdvice.java
@@ -3,6 +3,7 @@ package ProjectDoge.StudentSoup.exhandler.advice;
 import ProjectDoge.StudentSoup.exception.restaurant.RestaurantMenuNotFoundException;
 import ProjectDoge.StudentSoup.exception.restaurant.RestaurantMenuNotSentException;
 import ProjectDoge.StudentSoup.exception.restaurant.RestaurantMenuValidationException;
+import ProjectDoge.StudentSoup.exception.restaurant.RestaurantStarLikedMoreThanFiveException;
 import ProjectDoge.StudentSoup.exhandler.ErrorResult;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -30,8 +31,15 @@ public class RestaurantMenuAdvice {
 
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     @ExceptionHandler(RestaurantMenuNotSentException.class)
-    public ErrorResult restaurantMenuNotSentException(RestaurantMenuNotSentException e){
+    public ErrorResult restaurantMenuNotSentHandler(RestaurantMenuNotSentException e){
         log.error("[exceptionHandle] ex", e);
         return new ErrorResult("RestaurantMenuNotSent",e.getMessage());
+    }
+
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @ExceptionHandler(RestaurantStarLikedMoreThanFiveException.class)
+    public ErrorResult RestaurantStarLikedMoreThanFiveHandler(RestaurantStarLikedMoreThanFiveException e){
+        log.error("[exceptionHandle] ex", e);
+        return new ErrorResult("RestaurantStarLikedMoreThanFive",e.getMessage());
     }
 }

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/exhandler/advice/RestaurantMenuAdvice.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/exhandler/advice/RestaurantMenuAdvice.java
@@ -1,9 +1,6 @@
 package ProjectDoge.StudentSoup.exhandler.advice;
 
-import ProjectDoge.StudentSoup.exception.restaurant.RestaurantMenuNotFoundException;
-import ProjectDoge.StudentSoup.exception.restaurant.RestaurantMenuNotSentException;
-import ProjectDoge.StudentSoup.exception.restaurant.RestaurantMenuValidationException;
-import ProjectDoge.StudentSoup.exception.restaurant.RestaurantStarLikedMoreThanFiveException;
+import ProjectDoge.StudentSoup.exception.restaurant.*;
 import ProjectDoge.StudentSoup.exhandler.ErrorResult;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -41,5 +38,12 @@ public class RestaurantMenuAdvice {
     public ErrorResult RestaurantStarLikedMoreThanFiveHandler(RestaurantStarLikedMoreThanFiveException e){
         log.error("[exceptionHandle] ex", e);
         return new ErrorResult("RestaurantStarLikedMoreThanFive",e.getMessage());
+    }
+
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @ExceptionHandler(RestaurantReviewContentLessThanFiveException.class)
+    public ErrorResult RestaurantReviewContentLessThanFiveHandler(RestaurantReviewContentLessThanFiveException e){
+        log.error("[exceptionHandle] ex", e);
+        return new ErrorResult("RestaurantReviewContentLessThanFive",e.getMessage());
     }
 }

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/repository/restaurantreview/RestaurantReviewRepository.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/repository/restaurantreview/RestaurantReviewRepository.java
@@ -2,6 +2,8 @@ package ProjectDoge.StudentSoup.repository.restaurantreview;
 
 import ProjectDoge.StudentSoup.entity.restaurant.RestaurantReview;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
+@Repository
 public interface RestaurantReviewRepository extends JpaRepository<RestaurantReview, Long>, RestaurantReviewRepositoryCustom {
 }

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/repository/restaurantreview/RestaurantReviewRepositoryCustom.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/repository/restaurantreview/RestaurantReviewRepositoryCustom.java
@@ -1,4 +1,6 @@
 package ProjectDoge.StudentSoup.repository.restaurantreview;
 
 public interface RestaurantReviewRepositoryCustom {
+
+    Double avgByRestaurantId(Long restaurantId);
 }

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/repository/restaurantreview/RestaurantReviewRepositoryCustom.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/repository/restaurantreview/RestaurantReviewRepositoryCustom.java
@@ -3,4 +3,6 @@ package ProjectDoge.StudentSoup.repository.restaurantreview;
 public interface RestaurantReviewRepositoryCustom {
 
     Double avgByRestaurantId(Long restaurantId);
+
+    Long countByRestaurantId(Long restaurantId);
 }

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/repository/restaurantreview/RestaurantReviewRepositoryImpl.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/repository/restaurantreview/RestaurantReviewRepositoryImpl.java
@@ -23,4 +23,16 @@ public class RestaurantReviewRepositoryImpl implements RestaurantReviewRepositor
 
         return result.get(0);
     }
+
+    @Override
+    public Long countByRestaurantId(Long restaurantId) {
+
+        List<Long> result = queryFactory
+                .select(restaurantReview.count())
+                .from(restaurantReview)
+                .where(restaurantReview.restaurant.id.eq(restaurantId))
+                .fetch();
+
+        return result.get(0);
+    }
 }

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/repository/restaurantreview/RestaurantReviewRepositoryImpl.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/repository/restaurantreview/RestaurantReviewRepositoryImpl.java
@@ -1,4 +1,26 @@
 package ProjectDoge.StudentSoup.repository.restaurantreview;
 
-public class RestaurantReviewRepositoryImpl {
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+
+import java.util.List;
+
+import static ProjectDoge.StudentSoup.entity.restaurant.QRestaurantReview.restaurantReview;
+
+@RequiredArgsConstructor
+public class RestaurantReviewRepositoryImpl implements RestaurantReviewRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Double avgByRestaurantId(Long restaurantId) {
+        List<Double> result = queryFactory
+                .select(restaurantReview.starLiked.avg())
+                .from(restaurantReview)
+                .where(restaurantReview.restaurant.id.eq(restaurantId))
+                .fetch();
+
+
+        return result.get(0);
+    }
 }

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/service/restaurantreview/RestaurantReviewRegisterService.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/service/restaurantreview/RestaurantReviewRegisterService.java
@@ -29,7 +29,7 @@ public class RestaurantReviewRegisterService {
     private final FileRepository fileRepository;
     private final FileService fileService;
 
-    @Transactional
+    @Transactional(rollbackOn = Exception.class)
     public Long join(RestaurantReviewRequestDto dto){
         log.info("음식점 리뷰 등록 서비스가 실행되었습니다.");
         RestaurantReview restaurantReview = createRestaurantReview(dto);
@@ -38,6 +38,15 @@ public class RestaurantReviewRegisterService {
         RestaurantReview createdRestaurantReview = restaurantReviewRepository.save(restaurantReview);
         log.info("음식점 리뷰 등록이 완료되었습니다.");
         return createdRestaurantReview.getId();
+    }
+    @Transactional(rollbackOn = Exception.class)
+    public void starUpdate(Long restaurantId){
+        Restaurant restaurant = restaurantFindService.findOne(restaurantId);
+        log.info("레스토랑의 업데이트 전 별점 : [{}]", restaurant.getStarLiked());
+        double star = Math.round(restaurantReviewRepository.avgByRestaurantId(restaurantId) * 10) / 10.0;
+
+        restaurant.updateStarLiked(star);
+        log.info("레스토랑의 업데이트 된 별점 : [{}] , 쿼리 결과 별점 : [{}]", restaurant.getStarLiked(), star);
     }
 
     private RestaurantReview createRestaurantReview(RestaurantReviewRequestDto dto) {


### PR DESCRIPTION
## 1. Changes
- `Restaurant` 엔티티의 `starliked` 필드를 `float` -> `double` 로 반환타입을 수정하였습니다.
- `RestaurantReview` 엔티티에서 `menuName` 필드를 삭제하였습니다.
- 음식점 리뷰 등록 시 별점의 평균을 업데이트 할 수 있도록 서비스 로직을 수정하였습니다.
- 음식점 리뷰 등록 시 응답으로 별점의 평균과 리뷰의 개수를 받을 수 있도록 서비스 로직을 수정하였습니다.
- 리뷰 등록 시 별점이 5점을 초과했을 때 발생하는 예외를 추가했습니다.
- 리뷰 등록 시 리뷰의 내용이 5글자 이하인 경우에 대한 예외를 추가하였습니다.

## 2. Screenshot

- ![Image](https://user-images.githubusercontent.com/74203371/213724334-9169cbb0-099e-4944-9b69-443d1b2ed8c3.png)


## 3. Issues

1. 리뷰 등록 시 별점의 평균이 업데이트 되지 않는 문제가 있었습니다.
당연하게도 한 Transaction안에서 동작하면 Avg를 가지고 올 때 등록한 리뷰가 아직 커밋되지 않았기 때문에 Avg를 업데이트해서 가지고
올 수 없었습니다.

따라서 다음과 같이 Controller에서 한 번 호출 시 두 개의 서비스 로직을 수행하도록 하였습니다.
```java
 restaurantReviewRegisterService.join(dto);
 RestaurantReviewRegRespDto respDto = restaurantReviewRegisterService.starUpdate(restaurantId);
```

이로써 음식점의 별점 그리고 리뷰의 개수를 동시에 업데이트 해서 가지고 올 수 있었습니다.

2. 추가적으로 성능 개선에 대해서 공부를 하던 와중에 명시적 트랜잭션을 선언할 때, `readonly`, ~rollBackFor~ -> `rollbackon` 에 대해서 알게 되었습니다. `readonly`는 조회 쿼리에 대해서 `Transaction` 처리시 성능을 개선시킬 수 있다고 합니다. ex) `Paging` 조회 같은 경우에 사용
`rollbackon` 은 `Exception` 예외 발생 시 `RollBack`이 되지가 않는데, `Exception` 예외 발생 시에도 `Rollback`이 가능하도록 해주는 파라미터입니다.

## 4. To Reviewer

-

## 5. Plans

