### PR TITLE
mjw/modifyRestaurantDetailPaging

### DIFF
--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/controller/restaurant/RestaurantDetailCallController.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/controller/restaurant/RestaurantDetailCallController.java
@@ -5,6 +5,8 @@ import ProjectDoge.StudentSoup.dto.restaurant.RestaurantDetailRequestDto;
 import ProjectDoge.StudentSoup.service.restaurantmenu.RestaurantMenuCallService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.concurrent.ConcurrentHashMap;
@@ -18,7 +20,9 @@ public class RestaurantDetailCallController {
     private final RestaurantMenuCallService restaurantMenuCallService;
 
     @PostMapping("/{restaurantId}")
-    public ConcurrentHashMap<String, Object> callRestaurantDetail(@PathVariable Long restaurantId, @RequestBody RestaurantDetailRequestDto dto){
-        return restaurantMenuCallService.restaurantDetailCall(dto.getRestaurantId(), dto.getMemberId());
+    public ConcurrentHashMap<String, Object> callRestaurantDetail(@PathVariable Long restaurantId,
+                                                                  @RequestBody RestaurantDetailRequestDto dto,
+                                                                  @PageableDefault(size = 4) Pageable pageable){
+        return restaurantMenuCallService.restaurantDetailCall(dto.getRestaurantId(), dto.getMemberId(), pageable);
     }
 }

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/dto/restaurant/RestaurantDetailDto.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/dto/restaurant/RestaurantDetailDto.java
@@ -4,7 +4,6 @@ import ProjectDoge.StudentSoup.entity.file.ImageFile;
 import ProjectDoge.StudentSoup.entity.restaurant.Restaurant;
 import lombok.Data;
 
-import java.time.LocalTime;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -19,6 +18,7 @@ public class RestaurantDetailDto {
     private String endTime;
     private String distance;
     private List<String> fileName;
+    private String schoolName;
     private int reviewCount;
     private double starLiked;
     private int likedCount;
@@ -35,6 +35,7 @@ public class RestaurantDetailDto {
         this.startTime = restaurant.getStartTime().toString();
         this.endTime = restaurant.getEndTime().toString();
         this.fileName = setImageFile(restaurant);
+        this.schoolName = restaurant.getSchool().getSchoolName();
         this.reviewCount = restaurant.getRestaurantReviews().size();
         this.starLiked = restaurant.getStarLiked();
         this.likedCount = restaurant.getLikedCount();

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/dto/restaurant/RestaurantDetailDto.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/dto/restaurant/RestaurantDetailDto.java
@@ -15,8 +15,8 @@ public class RestaurantDetailDto {
     private Long restaurantId;
     private String name;
     private String address;
-    private LocalTime startTime;
-    private LocalTime endTime;
+    private String startTime;
+    private String endTime;
     private String distance;
     private List<String> fileName;
     private int reviewCount;
@@ -24,6 +24,7 @@ public class RestaurantDetailDto {
     private int likedCount;
     private int viewCount;
     private boolean like;
+    private String tag;
     private String detail;
 
     // 생성 메서드
@@ -31,8 +32,8 @@ public class RestaurantDetailDto {
         this.restaurantId = restaurant.getId();
         this.name = restaurant.getName();
         this.address = restaurant.getAddress();
-        this.startTime = restaurant.getStartTime();
-        this.endTime = restaurant.getEndTime();
+        this.startTime = restaurant.getStartTime().toString();
+        this.endTime = restaurant.getEndTime().toString();
         this.fileName = setImageFile(restaurant);
         this.reviewCount = restaurant.getRestaurantReviews().size();
         this.starLiked = restaurant.getStarLiked();
@@ -40,6 +41,7 @@ public class RestaurantDetailDto {
         this.viewCount = restaurant.getViewCount();
         this.distance = restaurant.getDistance() + "M";
         this.like = like;
+        this.tag = restaurant.getTag();
         this.detail = restaurant.getDetail();
         return this;
     }

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/dto/restaurant/RestaurantMenuDto.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/dto/restaurant/RestaurantMenuDto.java
@@ -13,7 +13,6 @@ public class RestaurantMenuDto {
     private String fileName;
     private int likedCount;
     private boolean like;
-    private float starLiked;
 
     public RestaurantMenuDto createRestaurantMenu(RestaurantMenu restaurantMenu, boolean like){
         this.restaurantMenuId = restaurantMenu.getId();
@@ -22,7 +21,6 @@ public class RestaurantMenuDto {
         this.cost = restaurantMenu.getCost();
         this.fileName = setImageFile(restaurantMenu);
         this.likedCount = restaurantMenu.getLikedCount();
-        this.starLiked = restaurantMenu.getStarLiked();
         this.like = like;
         return this;
     }

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/entity/restaurant/RestaurantMenu.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/entity/restaurant/RestaurantMenu.java
@@ -34,8 +34,6 @@ public class RestaurantMenu {
 
     private int likedCount;
 
-    private float starLiked;
-
     //== 연관관계 메서드 ==//
     public void setRestaurant(Restaurant restaurant){
         this.restaurant = restaurant;

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/init/TestDataInit.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/init/TestDataInit.java
@@ -218,6 +218,14 @@ public class TestDataInit {
                 "순대국밥",
                 RestaurantMenuCategory.Main,
                 8000);
+
+        for(int i = 0; i < 20; i++){
+            RestaurantMenuFormDto testDto = new RestaurantMenuFormDto().createRestaurantMenuDto(restaurant.getId(),
+                    "뼈해장국" + i,
+                    RestaurantMenuCategory.Main,
+                    9000);
+            restaurantMenuRegisterService.join(testDto);
+        }
         restaurantMenuRegisterService.join(dto);
         restaurantMenuRegisterService.join(dto2);
     }

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/repository/restaurantmenu/RestaurantMenuRepositoryCustom.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/repository/restaurantmenu/RestaurantMenuRepositoryCustom.java
@@ -1,6 +1,7 @@
 package ProjectDoge.StudentSoup.repository.restaurantmenu;
 
 import ProjectDoge.StudentSoup.entity.restaurant.RestaurantMenu;
+import org.springframework.data.domain.Pageable;
 
 import java.util.List;
 import java.util.Optional;
@@ -9,5 +10,6 @@ public interface RestaurantMenuRepositoryCustom {
 
     Optional<RestaurantMenu> findByRestaurantMenuNameAndRestaurant_RestaurantId(String menuName, Long restaurantId);
 
+    List<RestaurantMenu> findByRestaurantId(Long restaurantId, Pageable pageable);
     List<RestaurantMenu> findByRestaurantId(Long restaurantId);
 }

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/repository/restaurantmenu/RestaurantMenuRepositoryCustom.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/repository/restaurantmenu/RestaurantMenuRepositoryCustom.java
@@ -1,6 +1,7 @@
 package ProjectDoge.StudentSoup.repository.restaurantmenu;
 
 import ProjectDoge.StudentSoup.entity.restaurant.RestaurantMenu;
+import com.querydsl.jpa.impl.JPAQuery;
 import org.springframework.data.domain.Pageable;
 
 import java.util.List;
@@ -12,4 +13,5 @@ public interface RestaurantMenuRepositoryCustom {
 
     List<RestaurantMenu> findByRestaurantId(Long restaurantId, Pageable pageable);
     List<RestaurantMenu> findByRestaurantId(Long restaurantId);
+    JPAQuery<Long> countByRestaurantId(Long restaurantId);
 }

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/repository/restaurantmenu/RestaurantMenuRepositoryImpl.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/repository/restaurantmenu/RestaurantMenuRepositoryImpl.java
@@ -1,6 +1,7 @@
 package ProjectDoge.StudentSoup.repository.restaurantmenu;
 
 import ProjectDoge.StudentSoup.entity.restaurant.RestaurantMenu;
+import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
@@ -50,6 +51,15 @@ public class RestaurantMenuRepositoryImpl implements RestaurantMenuRepositoryCus
                 .where(restaurantMenu.restaurant.id.eq(restaurantId))
                 .fetch();
         return query;
+    }
+
+    @Override
+    public JPAQuery<Long> countByRestaurantId(Long restaurantId) {
+        return queryFactory
+                .select(restaurantMenu.count())
+                .from(restaurantMenu)
+                .where(restaurantMenu.restaurant.id.eq(restaurantId));
+
     }
 
 }

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/repository/restaurantmenu/RestaurantMenuRepositoryImpl.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/repository/restaurantmenu/RestaurantMenuRepositoryImpl.java
@@ -3,6 +3,7 @@ package ProjectDoge.StudentSoup.repository.restaurantmenu;
 import ProjectDoge.StudentSoup.entity.restaurant.RestaurantMenu;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
 
 import java.util.List;
 import java.util.Optional;
@@ -28,7 +29,20 @@ public class RestaurantMenuRepositoryImpl implements RestaurantMenuRepositoryCus
     }
 
     @Override
-    public List<RestaurantMenu> findByRestaurantId(Long restaurantId){
+    public List<RestaurantMenu> findByRestaurantId(Long restaurantId, Pageable pageable){
+        List<RestaurantMenu> query = queryFactory
+                .selectFrom(restaurantMenu)
+                .leftJoin(restaurantMenu.restaurant,restaurant)
+                .fetchJoin()
+                .where(restaurantMenu.restaurant.id.eq(restaurantId))
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+        return query;
+    }
+
+    @Override
+    public List<RestaurantMenu> findByRestaurantId(Long restaurantId) {
         List<RestaurantMenu> query = queryFactory
                 .selectFrom(restaurantMenu)
                 .leftJoin(restaurantMenu.restaurant,restaurant)


### PR DESCRIPTION
## 1. Changes
- 세부사항 페이지에 메뉴에 대해서 페이징을 적용했습니다.
- 음식점 세부사항 응답 데이터 전달 객체에 `startTime`, `endTime`은 양식에 맞게 포맷팅 하였고, `tag` 필드를 추가하였습니다.
- 음식점 세부사항 응답 데이터 전달 객체에 `schoolName`을 추가하였습니다.
- 음식점 세부사항 응답 데이터 전달 시 `pageable` 을 추가하였습니다.

## 2. Screenshot

-

## 3. Issues

1. 음식점 세부사항 응답 시 회원이 로그인을 안한 경우 프론트 분들이 `schoolName`을 세션에다 담아두어야 하는 문제가 있었습니다.
잦은 세션의 추가는 메모리에 추가 되고 생명주기가 끝날 때까지 남기 때문에 성능 저하의 우려가 있어서, `schoolName` 필드를 세부사항 전달 객체에 추가하였습니다.

2. 음식점 세부사항 전달 시 그럴 확률은 거의 없다고 생각하나 혹시 몰라서 `pageable`을 전달하게 되었습니다. 자세한 사항은 `Reviewer`를 참조해주세요.

## 4. To Reviewer

- @Trophy198 음식점 세부사항 첫 호출 시 `Menu` 관련 데이터에 `pageable` 데이터까지 포함해서 응답하게 되었습니다.
그럴 가능성은 굉장히 없을 거라 생각하나... 메뉴가 4개 이하일경우에 대한 대처입니다. 
만약 음식점 세부사항 첫 호출 시 총 호출 될 메뉴의 개수가 4개 이하라면 메뉴 아래에 있는 더보기가 안뜨도록 해주시면 됩니다. 


## 5. Plans
- [ ] - 음식점 메뉴 더보기 클릭 시 음식점 메뉴 전체 가져오기 서비스 로직 추가
- [ ] - 
