### PR TITLE
mjw/RestaurantReviewLikeService

### DIFF
--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/controller/admin/AdminRestaurantMenuController.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/controller/admin/AdminRestaurantMenuController.java
@@ -1,7 +1,7 @@
 package ProjectDoge.StudentSoup.controller.admin;
 
-import ProjectDoge.StudentSoup.dto.restaurant.RestaurantMenuFormDto;
-import ProjectDoge.StudentSoup.dto.restaurant.RestaurantMenuUpdateDto;
+import ProjectDoge.StudentSoup.dto.restaurantmenu.RestaurantMenuFormDto;
+import ProjectDoge.StudentSoup.dto.restaurantmenu.RestaurantMenuUpdateDto;
 import ProjectDoge.StudentSoup.entity.restaurant.Restaurant;
 import ProjectDoge.StudentSoup.entity.restaurant.RestaurantMenu;
 import ProjectDoge.StudentSoup.entity.restaurant.RestaurantMenuCategory;

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/controller/restaurant/RestaurantMenuLikeController.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/controller/restaurant/RestaurantMenuLikeController.java
@@ -12,13 +12,13 @@ import java.util.concurrent.ConcurrentHashMap;
 @Slf4j
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/restaurant")
+@RequestMapping("/restaurant/{restaurantId}")
 public class RestaurantMenuLikeController {
 
     private final RestaurantMenuLikeService restaurantMenuLikeService;
 
-    @PostMapping("/{restaurantId}/{restaurantMenuId}/like")
-    public ResponseEntity<ConcurrentHashMap<String, Object>> restaurantMenuLike(@PathVariable Long restaurantId, @PathVariable Long restaurantMenuId, @RequestBody RestaurantMenuLikeRequestDto dto){
+    @PostMapping("/menu/like")
+    public ResponseEntity<ConcurrentHashMap<String, Object>> restaurantMenuLike(@PathVariable Long restaurantId, @RequestBody RestaurantMenuLikeRequestDto dto){
         return ResponseEntity.ok(restaurantMenuLikeService.restaurantMenuLike(dto.getRestaurantMenuId(), dto.getMemberId()));
     }
 }

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/controller/restaurant/RestaurantMenuLikeController.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/controller/restaurant/RestaurantMenuLikeController.java
@@ -1,7 +1,6 @@
 package ProjectDoge.StudentSoup.controller.restaurant;
 
-import ProjectDoge.StudentSoup.dto.restaurant.RestaurantMenuLikeRequestDto;
-import ProjectDoge.StudentSoup.entity.restaurant.RestaurantMenuLike;
+import ProjectDoge.StudentSoup.dto.restaurantmenu.RestaurantMenuLikeRequestDto;
 import ProjectDoge.StudentSoup.service.restaurantmenu.RestaurantMenuLikeService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/controller/restaurantreview/RestaurantReviewCallController.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/controller/restaurantreview/RestaurantReviewCallController.java
@@ -1,7 +1,7 @@
 package ProjectDoge.StudentSoup.controller.restaurantreview;
 
-import ProjectDoge.StudentSoup.dto.restaurant.RestaurantReviewCallReqDto;
-import ProjectDoge.StudentSoup.dto.restaurant.RestaurantReviewDto;
+import ProjectDoge.StudentSoup.dto.restaurantreview.RestaurantReviewCallReqDto;
+import ProjectDoge.StudentSoup.dto.restaurantreview.RestaurantReviewDto;
 import ProjectDoge.StudentSoup.exception.page.PagingLimitEqualsZeroException;
 import ProjectDoge.StudentSoup.service.restaurantreview.RestaurantReviewCallService;
 import lombok.RequiredArgsConstructor;

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/controller/restaurantreview/RestaurantReviewLikeController.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/controller/restaurantreview/RestaurantReviewLikeController.java
@@ -17,10 +17,9 @@ public class RestaurantReviewLikeController {
 
     private final RestaurantReviewLikeService restaurantReviewLikeService;
 
-    @PostMapping("/{restaurantReviewId}/like")
+    @PostMapping("/review/like")
     public ResponseEntity<ConcurrentHashMap<String, Object>> restaurantReviewLike(
             @PathVariable Long restaurantId,
-            @PathVariable Long restaurantReviewId,
             @RequestBody RestaurantReviewLikeReqDto dto){
 
         ConcurrentHashMap<String, Object> resultMap = restaurantReviewLikeService.restaurantReviewLike(dto.getRestaurantReviewId(), dto.getMemberId());

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/controller/restaurantreview/RestaurantReviewLikeController.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/controller/restaurantreview/RestaurantReviewLikeController.java
@@ -1,0 +1,29 @@
+package ProjectDoge.StudentSoup.controller.restaurantreview;
+
+import ProjectDoge.StudentSoup.dto.restaurantreview.RestaurantReviewLikeReqDto;
+import ProjectDoge.StudentSoup.service.restaurantreview.RestaurantReviewLikeService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.concurrent.ConcurrentHashMap;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/restaurant/{restaurantId}")
+public class RestaurantReviewLikeController {
+
+    private final RestaurantReviewLikeService restaurantReviewLikeService;
+
+    @PostMapping("/{restaurantReviewId}/like")
+    public ResponseEntity<ConcurrentHashMap<String, Object>> restaurantReviewLike(
+            @PathVariable Long restaurantId,
+            @PathVariable Long restaurantReviewId,
+            @RequestBody RestaurantReviewLikeReqDto dto){
+
+        ConcurrentHashMap<String, Object> resultMap = restaurantReviewLikeService.restaurantReviewLike(dto.getRestaurantReviewId(), dto.getMemberId());
+        return ResponseEntity.ok(resultMap);
+    }
+}

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/controller/restaurantreview/RestaurantReviewRegisterController.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/controller/restaurantreview/RestaurantReviewRegisterController.java
@@ -1,8 +1,8 @@
 package ProjectDoge.StudentSoup.controller.restaurantreview;
 
 
-import ProjectDoge.StudentSoup.dto.restaurant.RestaurantReviewRegRespDto;
-import ProjectDoge.StudentSoup.dto.restaurant.RestaurantReviewRequestDto;
+import ProjectDoge.StudentSoup.dto.restaurantreview.RestaurantReviewRegRespDto;
+import ProjectDoge.StudentSoup.dto.restaurantreview.RestaurantReviewRequestDto;
 import ProjectDoge.StudentSoup.service.restaurantreview.RestaurantReviewRegisterService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/dto/restaurantmenu/RestaurantMenuDto.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/dto/restaurantmenu/RestaurantMenuDto.java
@@ -1,4 +1,4 @@
-package ProjectDoge.StudentSoup.dto.restaurant;
+package ProjectDoge.StudentSoup.dto.restaurantmenu;
 
 import ProjectDoge.StudentSoup.entity.file.ImageFile;
 import ProjectDoge.StudentSoup.entity.restaurant.RestaurantMenu;

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/dto/restaurantmenu/RestaurantMenuFormDto.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/dto/restaurantmenu/RestaurantMenuFormDto.java
@@ -1,4 +1,4 @@
-package ProjectDoge.StudentSoup.dto.restaurant;
+package ProjectDoge.StudentSoup.dto.restaurantmenu;
 
 import ProjectDoge.StudentSoup.entity.restaurant.RestaurantMenuCategory;
 import lombok.Getter;

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/dto/restaurantmenu/RestaurantMenuLikeRequestDto.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/dto/restaurantmenu/RestaurantMenuLikeRequestDto.java
@@ -1,4 +1,4 @@
-package ProjectDoge.StudentSoup.dto.restaurant;
+package ProjectDoge.StudentSoup.dto.restaurantmenu;
 
 import lombok.Data;
 

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/dto/restaurantmenu/RestaurantMenuUpdateDto.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/dto/restaurantmenu/RestaurantMenuUpdateDto.java
@@ -1,4 +1,4 @@
-package ProjectDoge.StudentSoup.dto.restaurant;
+package ProjectDoge.StudentSoup.dto.restaurantmenu;
 
 import ProjectDoge.StudentSoup.entity.restaurant.RestaurantMenu;
 import ProjectDoge.StudentSoup.entity.restaurant.RestaurantMenuCategory;

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/dto/restaurantreview/RestaurantReviewCallReqDto.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/dto/restaurantreview/RestaurantReviewCallReqDto.java
@@ -1,4 +1,4 @@
-package ProjectDoge.StudentSoup.dto.restaurant;
+package ProjectDoge.StudentSoup.dto.restaurantreview;
 
 import lombok.Data;
 

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/dto/restaurantreview/RestaurantReviewDto.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/dto/restaurantreview/RestaurantReviewDto.java
@@ -1,4 +1,4 @@
-package ProjectDoge.StudentSoup.dto.restaurant;
+package ProjectDoge.StudentSoup.dto.restaurantreview;
 
 import ProjectDoge.StudentSoup.entity.file.ImageFile;
 import ProjectDoge.StudentSoup.entity.member.Member;

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/dto/restaurantreview/RestaurantReviewFormDto.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/dto/restaurantreview/RestaurantReviewFormDto.java
@@ -1,4 +1,4 @@
-package ProjectDoge.StudentSoup.dto.restaurant;
+package ProjectDoge.StudentSoup.dto.restaurantreview;
 
 import lombok.Getter;
 import lombok.Setter;

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/dto/restaurantreview/RestaurantReviewLikeReqDto.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/dto/restaurantreview/RestaurantReviewLikeReqDto.java
@@ -1,0 +1,10 @@
+package ProjectDoge.StudentSoup.dto.restaurantreview;
+
+import lombok.Data;
+
+@Data
+public class RestaurantReviewLikeReqDto {
+
+    private Long restaurantReviewId;
+    private Long memberId;
+}

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/dto/restaurantreview/RestaurantReviewRegRespDto.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/dto/restaurantreview/RestaurantReviewRegRespDto.java
@@ -1,4 +1,4 @@
-package ProjectDoge.StudentSoup.dto.restaurant;
+package ProjectDoge.StudentSoup.dto.restaurantreview;
 
 import lombok.Getter;
 import lombok.Setter;

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/dto/restaurantreview/RestaurantReviewRequestDto.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/dto/restaurantreview/RestaurantReviewRequestDto.java
@@ -1,4 +1,4 @@
-package ProjectDoge.StudentSoup.dto.restaurant;
+package ProjectDoge.StudentSoup.dto.restaurantreview;
 
 import lombok.Data;
 import org.springframework.web.multipart.MultipartFile;

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/entity/restaurant/RestaurantMenu.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/entity/restaurant/RestaurantMenu.java
@@ -1,7 +1,7 @@
 package ProjectDoge.StudentSoup.entity.restaurant;
 
-import ProjectDoge.StudentSoup.dto.restaurant.RestaurantMenuFormDto;
-import ProjectDoge.StudentSoup.dto.restaurant.RestaurantMenuUpdateDto;
+import ProjectDoge.StudentSoup.dto.restaurantmenu.RestaurantMenuFormDto;
+import ProjectDoge.StudentSoup.dto.restaurantmenu.RestaurantMenuUpdateDto;
 import ProjectDoge.StudentSoup.entity.file.ImageFile;
 import lombok.Getter;
 import lombok.Setter;

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/entity/restaurant/RestaurantReview.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/entity/restaurant/RestaurantReview.java
@@ -97,5 +97,13 @@ public class RestaurantReview {
             imageFile.setRestaurantReview(this);
     }
 
+    public void addLikedCount(){
+        this.likedCount += 1;
+    }
+    public void minusLikedCount(){
+        if(this.likedCount != 0) {
+            this.likedCount -= 1;
+        }
+    }
 
 }

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/entity/restaurant/RestaurantReview.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/entity/restaurant/RestaurantReview.java
@@ -1,6 +1,6 @@
 package ProjectDoge.StudentSoup.entity.restaurant;
 
-import ProjectDoge.StudentSoup.dto.restaurant.RestaurantReviewRequestDto;
+import ProjectDoge.StudentSoup.dto.restaurantreview.RestaurantReviewRequestDto;
 import ProjectDoge.StudentSoup.entity.file.ImageFile;
 import ProjectDoge.StudentSoup.entity.member.Member;
 import lombok.Getter;

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/entity/restaurant/RestaurantReviewLike.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/entity/restaurant/RestaurantReviewLike.java
@@ -32,4 +32,10 @@ public class RestaurantReviewLike {
     public void setRestaurant(RestaurantReview restaurantReview){
         restaurantReview.getRestaurantReviewLikes().add(this);
     }
+
+    //== 생성 메서드 ==//
+    public RestaurantReviewLike(RestaurantReview review, Member member){
+        this.restaurantReview = review;
+        this.member = member;
+    }
 }

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/entity/restaurant/RestaurantReviewLike.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/entity/restaurant/RestaurantReviewLike.java
@@ -34,8 +34,9 @@ public class RestaurantReviewLike {
     }
 
     //== 생성 메서드 ==//
-    public RestaurantReviewLike(RestaurantReview review, Member member){
+    public RestaurantReviewLike createRestaurantReviewLike(RestaurantReview review, Member member){
         this.restaurantReview = review;
         this.member = member;
+        return this;
     }
 }

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/exception/restaurant/RestaurantReviewIdNotSentException.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/exception/restaurant/RestaurantReviewIdNotSentException.java
@@ -1,0 +1,23 @@
+package ProjectDoge.StudentSoup.exception.restaurant;
+
+public class RestaurantReviewIdNotSentException extends RuntimeException {
+    public RestaurantReviewIdNotSentException() {
+        super();
+    }
+
+    public RestaurantReviewIdNotSentException(String message) {
+        super(message);
+    }
+
+    public RestaurantReviewIdNotSentException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public RestaurantReviewIdNotSentException(Throwable cause) {
+        super(cause);
+    }
+
+    protected RestaurantReviewIdNotSentException(String message, Throwable cause, boolean enableSuppression, boolean writableStackTrace) {
+        super(message, cause, enableSuppression, writableStackTrace);
+    }
+}

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/exhandler/advice/RestaurantReviewAdvice.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/exhandler/advice/RestaurantReviewAdvice.java
@@ -1,0 +1,22 @@
+package ProjectDoge.StudentSoup.exhandler.advice;
+
+import ProjectDoge.StudentSoup.exception.restaurant.RestaurantMenuIdNotSentException;
+import ProjectDoge.StudentSoup.exception.restaurant.RestaurantReviewIdNotSentException;
+import ProjectDoge.StudentSoup.exhandler.ErrorResult;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice
+public class RestaurantReviewAdvice {
+
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @ExceptionHandler(RestaurantReviewIdNotSentException.class)
+    public ErrorResult restaurantReviewIdNotSentHandler(RestaurantReviewIdNotSentException e){
+        log.error("[exceptionHandle] ex", e);
+        return new ErrorResult("RestaurantReviewIdNotSent",e.getMessage());
+    }
+}

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/init/TestDataInit.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/init/TestDataInit.java
@@ -4,29 +4,24 @@ import ProjectDoge.StudentSoup.dto.board.BoardFormDto;
 import ProjectDoge.StudentSoup.dto.department.DepartmentFormDto;
 import ProjectDoge.StudentSoup.dto.member.MemberFormBDto;
 import ProjectDoge.StudentSoup.dto.restaurant.RestaurantFormDto;
-import ProjectDoge.StudentSoup.dto.restaurant.RestaurantMenuFormDto;
+import ProjectDoge.StudentSoup.dto.restaurantmenu.RestaurantMenuFormDto;
 import ProjectDoge.StudentSoup.dto.school.SchoolFormDto;
 import ProjectDoge.StudentSoup.entity.board.Board;
 import ProjectDoge.StudentSoup.entity.board.BoardCategory;
 import ProjectDoge.StudentSoup.entity.board.BoardLike;
-import ProjectDoge.StudentSoup.entity.file.ImageFile;
 import ProjectDoge.StudentSoup.entity.member.GenderType;
 import ProjectDoge.StudentSoup.entity.member.Member;
 import ProjectDoge.StudentSoup.entity.restaurant.Restaurant;
 import ProjectDoge.StudentSoup.entity.restaurant.RestaurantCategory;
-import ProjectDoge.StudentSoup.entity.restaurant.RestaurantLike;
 import ProjectDoge.StudentSoup.entity.restaurant.RestaurantMenuCategory;
 import ProjectDoge.StudentSoup.entity.school.Department;
-import ProjectDoge.StudentSoup.entity.school.School;
 import ProjectDoge.StudentSoup.repository.board.BoardLikeRepository;
 import ProjectDoge.StudentSoup.repository.board.BoardRepository;
 import ProjectDoge.StudentSoup.repository.department.DepartmentRepository;
 import ProjectDoge.StudentSoup.repository.member.MemberRepository;
 import ProjectDoge.StudentSoup.repository.school.SchoolRepository;
-import ProjectDoge.StudentSoup.service.board.BoardLikeService;
 import ProjectDoge.StudentSoup.service.board.BoardResisterService;
 import ProjectDoge.StudentSoup.service.department.DepartmentRegisterService;
-import ProjectDoge.StudentSoup.service.member.MemberFindService;
 import ProjectDoge.StudentSoup.service.member.MemberRegisterService;
 import ProjectDoge.StudentSoup.service.restaurant.RestaurantFindService;
 import ProjectDoge.StudentSoup.service.restaurant.RestaurantRegisterService;
@@ -41,7 +36,6 @@ import org.springframework.stereotype.Component;
 
 import java.time.LocalTime;
 import java.util.List;
-import java.util.Optional;
 
 @Component
 @Profile("local")

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/repository/restaurantreview/RestaurantReviewLikeRepository.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/repository/restaurantreview/RestaurantReviewLikeRepository.java
@@ -1,0 +1,4 @@
+package ProjectDoge.StudentSoup.repository.restaurantreview;
+
+public interface RestaurantReviewLikeRepository {
+}

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/repository/restaurantreview/RestaurantReviewLikeRepository.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/repository/restaurantreview/RestaurantReviewLikeRepository.java
@@ -1,4 +1,7 @@
 package ProjectDoge.StudentSoup.repository.restaurantreview;
 
-public interface RestaurantReviewLikeRepository {
+import ProjectDoge.StudentSoup.entity.restaurant.RestaurantReviewLike;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RestaurantReviewLikeRepository extends JpaRepository<RestaurantReviewLike, Long>, RestaurantReviewLikeRepositoryCustom {
 }

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/repository/restaurantreview/RestaurantReviewLikeRepositoryCustom.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/repository/restaurantreview/RestaurantReviewLikeRepositoryCustom.java
@@ -1,0 +1,4 @@
+package ProjectDoge.StudentSoup.repository.restaurantreview;
+
+public interface RestaurantReviewLikeRepositoryCustom {
+}

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/repository/restaurantreview/RestaurantReviewLikeRepositoryCustom.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/repository/restaurantreview/RestaurantReviewLikeRepositoryCustom.java
@@ -1,4 +1,10 @@
 package ProjectDoge.StudentSoup.repository.restaurantreview;
 
+import ProjectDoge.StudentSoup.entity.restaurant.RestaurantReviewLike;
+
+import java.util.Optional;
+
 public interface RestaurantReviewLikeRepositoryCustom {
+
+    Optional<RestaurantReviewLike> findRestaurantReviewLikeByReviewIdAndMemberId(Long restaurantReviewId, Long memberId);
 }

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/repository/restaurantreview/RestaurantReviewLikeRepositoryImpl.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/repository/restaurantreview/RestaurantReviewLikeRepositoryImpl.java
@@ -1,4 +1,28 @@
 package ProjectDoge.StudentSoup.repository.restaurantreview;
 
-public class RestaurantReviewLikeRepositoryImpl {
+import ProjectDoge.StudentSoup.entity.restaurant.RestaurantMenuLike;
+import ProjectDoge.StudentSoup.entity.restaurant.RestaurantReviewLike;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+
+import java.util.Optional;
+
+import static ProjectDoge.StudentSoup.entity.restaurant.QRestaurantMenuLike.restaurantMenuLike;
+import static ProjectDoge.StudentSoup.entity.restaurant.QRestaurantReviewLike.restaurantReviewLike;
+
+@RequiredArgsConstructor
+public class RestaurantReviewLikeRepositoryImpl implements RestaurantReviewLikeRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Optional<RestaurantReviewLike> findRestaurantReviewLikeByReviewIdAndMemberId(Long restaurantReviewId, Long memberId) {
+
+        RestaurantReviewLike query = queryFactory.select(restaurantReviewLike)
+                .from(restaurantReviewLike)
+                .where(restaurantReviewLike.restaurantReview.id.eq(restaurantReviewId), restaurantReviewLike.member.memberId.eq(memberId))
+                .fetchOne();
+
+        return Optional.ofNullable(query);
+    }
 }

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/repository/restaurantreview/RestaurantReviewLikeRepositoryImpl.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/repository/restaurantreview/RestaurantReviewLikeRepositoryImpl.java
@@ -1,0 +1,4 @@
+package ProjectDoge.StudentSoup.repository.restaurantreview;
+
+public class RestaurantReviewLikeRepositoryImpl {
+}

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/service/admin/AdminRestaurantMenuService.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/service/admin/AdminRestaurantMenuService.java
@@ -1,6 +1,6 @@
 package ProjectDoge.StudentSoup.service.admin;
 
-import ProjectDoge.StudentSoup.dto.restaurant.RestaurantMenuUpdateDto;
+import ProjectDoge.StudentSoup.dto.restaurantmenu.RestaurantMenuUpdateDto;
 import ProjectDoge.StudentSoup.entity.file.ImageFile;
 import ProjectDoge.StudentSoup.entity.restaurant.RestaurantMenu;
 import ProjectDoge.StudentSoup.repository.file.FileRepository;

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/service/restaurantmenu/RestaurantMenuCallService.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/service/restaurantmenu/RestaurantMenuCallService.java
@@ -1,7 +1,7 @@
 package ProjectDoge.StudentSoup.service.restaurantmenu;
 
 import ProjectDoge.StudentSoup.dto.restaurant.RestaurantDetailDto;
-import ProjectDoge.StudentSoup.dto.restaurant.RestaurantMenuDto;
+import ProjectDoge.StudentSoup.dto.restaurantmenu.RestaurantMenuDto;
 import ProjectDoge.StudentSoup.entity.restaurant.Restaurant;
 import ProjectDoge.StudentSoup.entity.restaurant.RestaurantLike;
 import ProjectDoge.StudentSoup.entity.restaurant.RestaurantMenu;

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/service/restaurantmenu/RestaurantMenuLikeService.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/service/restaurantmenu/RestaurantMenuLikeService.java
@@ -1,6 +1,6 @@
 package ProjectDoge.StudentSoup.service.restaurantmenu;
 
-import ProjectDoge.StudentSoup.dto.restaurant.RestaurantMenuDto;
+import ProjectDoge.StudentSoup.dto.restaurantmenu.RestaurantMenuDto;
 import ProjectDoge.StudentSoup.entity.member.Member;
 import ProjectDoge.StudentSoup.entity.restaurant.RestaurantMenu;
 import ProjectDoge.StudentSoup.entity.restaurant.RestaurantMenuLike;

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/service/restaurantmenu/RestaurantMenuRegisterService.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/service/restaurantmenu/RestaurantMenuRegisterService.java
@@ -1,6 +1,6 @@
 package ProjectDoge.StudentSoup.service.restaurantmenu;
 
-import ProjectDoge.StudentSoup.dto.restaurant.RestaurantMenuFormDto;
+import ProjectDoge.StudentSoup.dto.restaurantmenu.RestaurantMenuFormDto;
 import ProjectDoge.StudentSoup.entity.file.ImageFile;
 import ProjectDoge.StudentSoup.entity.restaurant.Restaurant;
 import ProjectDoge.StudentSoup.entity.restaurant.RestaurantMenu;

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/service/restaurantmenu/RestaurantMenuValidationService.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/service/restaurantmenu/RestaurantMenuValidationService.java
@@ -1,6 +1,6 @@
 package ProjectDoge.StudentSoup.service.restaurantmenu;
 
-import ProjectDoge.StudentSoup.dto.restaurant.RestaurantMenuFormDto;
+import ProjectDoge.StudentSoup.dto.restaurantmenu.RestaurantMenuFormDto;
 import ProjectDoge.StudentSoup.exception.restaurant.RestaurantMenuValidationException;
 import ProjectDoge.StudentSoup.repository.restaurantmenu.RestaurantMenuRepository;
 import lombok.RequiredArgsConstructor;

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/service/restaurantreview/RestaurantReviewCallService.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/service/restaurantreview/RestaurantReviewCallService.java
@@ -1,6 +1,6 @@
 package ProjectDoge.StudentSoup.service.restaurantreview;
 
-import ProjectDoge.StudentSoup.dto.restaurant.RestaurantReviewDto;
+import ProjectDoge.StudentSoup.dto.restaurantreview.RestaurantReviewDto;
 import ProjectDoge.StudentSoup.entity.restaurant.RestaurantReview;
 import ProjectDoge.StudentSoup.entity.restaurant.RestaurantReviewLike;
 import ProjectDoge.StudentSoup.repository.restaurantreview.RestaurantReviewRepository;

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/service/restaurantreview/RestaurantReviewFindService.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/service/restaurantreview/RestaurantReviewFindService.java
@@ -1,0 +1,33 @@
+package ProjectDoge.StudentSoup.service.restaurantreview;
+
+import ProjectDoge.StudentSoup.entity.restaurant.RestaurantMenu;
+import ProjectDoge.StudentSoup.entity.restaurant.RestaurantReview;
+import ProjectDoge.StudentSoup.exception.restaurant.RestaurantMenuIdNotSentException;
+import ProjectDoge.StudentSoup.exception.restaurant.RestaurantMenuNotFoundException;
+import ProjectDoge.StudentSoup.exception.restaurant.RestaurantReviewIdNotSentException;
+import ProjectDoge.StudentSoup.repository.restaurantreview.RestaurantReviewRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class RestaurantReviewFindService {
+
+    private final RestaurantReviewRepository restaurantReviewRepository;
+
+    public RestaurantReview findOne(Long restaurantReviewId){
+        checkRestaurantMenuIdSent(restaurantReviewId);
+        return restaurantReviewRepository.findById(restaurantReviewId).orElseThrow(() -> {
+            return new RestaurantMenuNotFoundException("등록되지 않은 메뉴 입니다.");
+        });
+    }
+
+    private void checkRestaurantMenuIdSent(Long restaurantReviewId) {
+        if (restaurantReviewId == null){
+            log.info("RestaurantReviewId가 전송되지 않았습니다.");
+            throw new RestaurantReviewIdNotSentException("restaurantReviewId가 전송되지 않았습니다.");
+        }
+    }
+}

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/service/restaurantreview/RestaurantReviewLikeService.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/service/restaurantreview/RestaurantReviewLikeService.java
@@ -77,7 +77,7 @@ public class RestaurantReviewLikeService {
 
     private void likeRestaurantReview(Member member, RestaurantReview restaurantReview, ConcurrentHashMap<String, Object> resultMap){
         log.info("음식점 리뷰 좋아요 서비스 로직이 실행되었습니다.");
-        RestaurantReviewLike restaurantReviewLike = new RestaurantReviewLike(restaurantReview, member);
+        RestaurantReviewLike restaurantReviewLike = new RestaurantReviewLike().createRestaurantReviewLike(restaurantReview, member);
         restaurantReviewLikeRepository.save(restaurantReviewLike);
         restaurantReview.addLikedCount();
 

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/service/restaurantreview/RestaurantReviewLikeService.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/service/restaurantreview/RestaurantReviewLikeService.java
@@ -1,0 +1,90 @@
+package ProjectDoge.StudentSoup.service.restaurantreview;
+
+import ProjectDoge.StudentSoup.dto.restaurant.RestaurantReviewDto;
+import ProjectDoge.StudentSoup.entity.member.Member;
+import ProjectDoge.StudentSoup.entity.restaurant.RestaurantReview;
+import ProjectDoge.StudentSoup.entity.restaurant.RestaurantReviewLike;
+import ProjectDoge.StudentSoup.exception.member.MemberNotFoundException;
+import ProjectDoge.StudentSoup.repository.restaurantreview.RestaurantReviewLikeRepository;
+import ProjectDoge.StudentSoup.service.member.MemberFindService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import javax.transaction.Transactional;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class RestaurantReviewLikeService {
+
+    private final RestaurantReviewLikeRepository restaurantReviewLikeRepository;
+    private final RestaurantReviewFindService restaurantReviewFindService;
+    private final MemberFindService memberFindService;
+
+    boolean restaurantReviewLiked = true;
+    boolean restaurantReviewNotLiked = false;
+
+    @Transactional
+    public ConcurrentHashMap<String, Object> restaurantReviewLike(Long restaurantReviewId, Long memberId){
+        ConcurrentHashMap<String, Object> resultMap = new ConcurrentHashMap<>();
+        Long restaurantReviewLikeId = isAlreadyRestaurantReviewLiked(restaurantReviewId, memberId);
+        RestaurantReview restaurantReview = restaurantReviewFindService.findOne(restaurantReviewId);
+        if(restaurantReviewLikeId != null){
+            unlikeRestaurantReview(restaurantReviewLikeId, restaurantReview, resultMap);
+        } else {
+            Member member = memberFindService.findOne(memberId);
+            likeRestaurantReview(member, restaurantReview, resultMap);
+        }
+        return resultMap;
+    }
+
+    private Long isAlreadyRestaurantReviewLiked(Long restaurantReviewId, Long memberId){
+        log.info("회원이 이미 좋아요를 눌렀는지 체크하는 로직이 실행되었습니다. 음식점 리뷰 ID : [{}] , 회원 ID : [{}]", restaurantReviewId, memberId);
+        isLoginMember(memberId);
+        RestaurantReviewLike restaurantReviewLike = restaurantReviewLikeRepository.findRestaurantReviewLikeByReviewIdAndMemberId(restaurantReviewId, memberId)
+                .orElse(null);
+        if(restaurantReviewLike == null) {
+            log.info("[{}]님은 해당 음식점 리뷰[{}]의 좋아요를 누른 상태가 아닙니다.", memberId, restaurantReviewId);
+            return null;
+        }
+        log.info("[{}]님은 해당 음식점 리뷰[{}]의 좋아요를 누른 상태입니다..", memberId, restaurantReviewId);
+        return restaurantReviewLike.getId();
+    }
+
+    private void isLoginMember(Long memberId){
+        log.info("회원이 로그인이 되었는지 확인하는 로직이 실행되었습니다.");
+        if(memberId == null){
+            log.info("회원의 기본키가 전달이 되지 않았거나 로그인이 되어있지 않은 상태입니다.");
+            throw new MemberNotFoundException("회원이 로그인이 되어있지 않은 상태이거나, 기본키가 전달 되지 않았습니다.");
+        }
+        log.info("회원이 로그인이 되어있는 상태입니다.");
+    }
+
+    private void unlikeRestaurantReview(Long restaurantReviewLikeId, RestaurantReview restaurantReview, ConcurrentHashMap<String, Object> resultMap) {
+        log.info("음식점 리뷰 좋아요 취소 서비스 로직이 실행되었습니다.");
+        restaurantReviewLikeRepository.deleteById(restaurantReviewLikeId);
+        restaurantReview.minusLikedCount();
+
+        RestaurantReviewDto dto = new RestaurantReviewDto(restaurantReview, restaurantReviewNotLiked);
+        resultMap.put("data", dto);
+        resultMap.put("result", "cancel");
+
+        log.info("음식점 리뷰 좋아요가 취소 되었습니다. 좋아요 수 : [{}]", restaurantReview.getLikedCount());
+
+    }
+
+    private void likeRestaurantReview(Member member, RestaurantReview restaurantReview, ConcurrentHashMap<String, Object> resultMap){
+        log.info("음식점 리뷰 좋아요 서비스 로직이 실행되었습니다.");
+        RestaurantReviewLike restaurantReviewLike = new RestaurantReviewLike(restaurantReview, member);
+        restaurantReviewLikeRepository.save(restaurantReviewLike);
+        restaurantReview.addLikedCount();
+
+        RestaurantReviewDto dto = new RestaurantReviewDto(restaurantReview, restaurantReviewLiked);
+        resultMap.put("data", dto);
+        resultMap.put("result", "like");
+
+        log.info("음식점 리뷰 좋아요가 완료 되었습니다. 좋아요 수 : [{}]", restaurantReview.getLikedCount());
+    }
+}

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/service/restaurantreview/RestaurantReviewLikeService.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/service/restaurantreview/RestaurantReviewLikeService.java
@@ -1,6 +1,6 @@
 package ProjectDoge.StudentSoup.service.restaurantreview;
 
-import ProjectDoge.StudentSoup.dto.restaurant.RestaurantReviewDto;
+import ProjectDoge.StudentSoup.dto.restaurantreview.RestaurantReviewDto;
 import ProjectDoge.StudentSoup.entity.member.Member;
 import ProjectDoge.StudentSoup.entity.restaurant.RestaurantReview;
 import ProjectDoge.StudentSoup.entity.restaurant.RestaurantReviewLike;

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/service/restaurantreview/RestaurantReviewRegisterService.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/service/restaurantreview/RestaurantReviewRegisterService.java
@@ -1,8 +1,8 @@
 package ProjectDoge.StudentSoup.service.restaurantreview;
 
 import ProjectDoge.StudentSoup.dto.file.UploadFileDto;
-import ProjectDoge.StudentSoup.dto.restaurant.RestaurantReviewRegRespDto;
-import ProjectDoge.StudentSoup.dto.restaurant.RestaurantReviewRequestDto;
+import ProjectDoge.StudentSoup.dto.restaurantreview.RestaurantReviewRegRespDto;
+import ProjectDoge.StudentSoup.dto.restaurantreview.RestaurantReviewRequestDto;
 import ProjectDoge.StudentSoup.entity.file.ImageFile;
 import ProjectDoge.StudentSoup.entity.member.Member;
 import ProjectDoge.StudentSoup.entity.restaurant.Restaurant;

--- a/StudentSoup/src/test/java/ProjectDoge/StudentSoup/restaurant/RestaurantMenuEntityTest.java
+++ b/StudentSoup/src/test/java/ProjectDoge/StudentSoup/restaurant/RestaurantMenuEntityTest.java
@@ -1,7 +1,7 @@
 package ProjectDoge.StudentSoup.restaurant;
 
 import ProjectDoge.StudentSoup.dto.restaurant.RestaurantFormDto;
-import ProjectDoge.StudentSoup.dto.restaurant.RestaurantMenuFormDto;
+import ProjectDoge.StudentSoup.dto.restaurantmenu.RestaurantMenuFormDto;
 import ProjectDoge.StudentSoup.dto.school.SchoolFormDto;
 import ProjectDoge.StudentSoup.entity.file.ImageFile;
 import ProjectDoge.StudentSoup.entity.restaurant.Restaurant;


### PR DESCRIPTION
## 1. Changes
- 음식점 메뉴 좋아요 URI를 `/restaurant/{restaurantId}/{restaurantMenuId}/like` 에서 `/restaurant/{restaurantId}/menu/like` 로 변경하였습니다.
- 음식점 리뷰 좋아요 / 좋아요 취소 서비스 로직을 구현하였습니다.
- 음식점 리뷰를 탐색하는 서비스 로직을 구현하였습니다.
- 음식점 리뷰 기본키가 전달되지 않았을 경우의 예외를 추가하였습니다.
- 회원이 이미 음식점 리뷰를 좋아요를 했는지를 확인하는 서비스 로직을 구현하였습니다.
- 음식점 리뷰 좋아요 및 좋아요 취소 시 좋아요 수를 업데이트 하는 비즈니스 로직을 구현하였습니다.

## 2. Screenshot

-

## 3. Issues

1. 음식점 리뷰 좋아요를 생성할 때, 음식점 리뷰와 회원 엔티티를 가지고 음식점 리뷰 엔티티를 생성하는 생성자를 추가했었습니다.
이 때, 엔티티에 기본 생성자가 존재하지 않아 `no default Constructor` 예외가 발생했습니다. 물론 `NoArgsConstructor` 애노테이션을 추가하면 해당 문제가 해결 될 일이지만, 값이 없는 비어있는 엔티티가 생길 경우를 우려하여 기존과 같이 메소드로 수정하였습니다. 

2. 음식점 메뉴 좋아요에 대한 URI를 수정하게 되었습니다.
기존 URI는 다음과 같았습니다. `/restaurant/{restaurantId}/{restaurantMenuId}/like` 
이러한 상태에서 `/restaurant/{restaurantId}/{restaurantReviewId}/like` 를 추가했을 때, 
두 개의 URI가 겹치는 문제가 있었습니다.
이에 따라 좋아요와 관련된 URI를 `/restaurant/{restaurantId}/menu/like`, `/restaurant/{restaurantId}/review/like` 로 수정하였습니다.

## 4. To Reviewer

- @Trophy198 이슈 확인 부탁드립니다.

## 5. Plans

