### PR TITLE
mjw/deleteRestaurantReview

### DIFF
--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/controller/restaurantreview/RestaurantDeleteController.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/controller/restaurantreview/RestaurantDeleteController.java
@@ -1,0 +1,32 @@
+package ProjectDoge.StudentSoup.controller.restaurantreview;
+
+import ProjectDoge.StudentSoup.dto.restaurantreview.RestaurantReviewDeleteDto;
+import ProjectDoge.StudentSoup.service.restaurantreview.RestaurantReviewDeleteService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.concurrent.ConcurrentHashMap;
+
+@Slf4j
+@RestController
+@RequestMapping("/restaurant/{restaurantId}/review")
+@RequiredArgsConstructor
+public class RestaurantDeleteController {
+
+    private final RestaurantReviewDeleteService restaurantReviewDeleteService;
+
+    @DeleteMapping("/{restaurantReviewId}")
+    public ResponseEntity<ConcurrentHashMap<String, String>> deleteRestaurantReview(
+            @PathVariable Long restaurantId,
+            @PathVariable Long restaurantReviewId,
+            @RequestBody RestaurantReviewDeleteDto dto){
+        log.info("리뷰 삭제가 호출되었습니다.");
+        ConcurrentHashMap<String, String> resultMap = restaurantReviewDeleteService.deleteRestaurantReview(
+                dto.getRestaurantId(),
+                dto.getMemberId());
+
+        return ResponseEntity.ok(resultMap);
+    }
+}

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/controller/restaurantreview/RestaurantReviewDeleteController.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/controller/restaurantreview/RestaurantReviewDeleteController.java
@@ -11,16 +11,15 @@ import java.util.concurrent.ConcurrentHashMap;
 
 @Slf4j
 @RestController
-@RequestMapping("/restaurant/{restaurantId}/review")
+@RequestMapping("/restaurant/{restaurantId}")
 @RequiredArgsConstructor
 public class RestaurantReviewDeleteController {
 
     private final RestaurantReviewDeleteService restaurantReviewDeleteService;
 
-    @DeleteMapping("/{restaurantReviewId}")
+    @DeleteMapping("/review")
     public ResponseEntity<ConcurrentHashMap<String, String>> deleteRestaurantReview(
             @PathVariable Long restaurantId,
-            @PathVariable Long restaurantReviewId,
             @RequestBody RestaurantReviewDeleteDto dto){
         log.info("리뷰 삭제가 호출되었습니다.");
         ConcurrentHashMap<String, String> resultMap = restaurantReviewDeleteService.deleteRestaurantReview(

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/controller/restaurantreview/RestaurantReviewDeleteController.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/controller/restaurantreview/RestaurantReviewDeleteController.java
@@ -23,7 +23,7 @@ public class RestaurantReviewDeleteController {
             @RequestBody RestaurantReviewDeleteDto dto){
         log.info("리뷰 삭제가 호출되었습니다.");
         ConcurrentHashMap<String, String> resultMap = restaurantReviewDeleteService.deleteRestaurantReview(
-                dto.getRestaurantId(),
+                dto.getRestaurantReviewId(),
                 dto.getMemberId());
 
         return ResponseEntity.ok(resultMap);

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/controller/restaurantreview/RestaurantReviewDeleteController.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/controller/restaurantreview/RestaurantReviewDeleteController.java
@@ -13,7 +13,7 @@ import java.util.concurrent.ConcurrentHashMap;
 @RestController
 @RequestMapping("/restaurant/{restaurantId}/review")
 @RequiredArgsConstructor
-public class RestaurantDeleteController {
+public class RestaurantReviewDeleteController {
 
     private final RestaurantReviewDeleteService restaurantReviewDeleteService;
 

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/dto/restaurantreview/RestaurantReviewDeleteDto.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/dto/restaurantreview/RestaurantReviewDeleteDto.java
@@ -5,6 +5,6 @@ import lombok.Data;
 @Data
 public class RestaurantReviewDeleteDto {
 
-    private Long restaurantId;
+    private Long restaurantReviewId;
     private Long memberId;
 }

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/dto/restaurantreview/RestaurantReviewDeleteDto.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/dto/restaurantreview/RestaurantReviewDeleteDto.java
@@ -1,0 +1,10 @@
+package ProjectDoge.StudentSoup.dto.restaurantreview;
+
+import lombok.Data;
+
+@Data
+public class RestaurantReviewDeleteDto {
+
+    private Long restaurantId;
+    private Long memberId;
+}

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/entity/member/MemberClassification.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/entity/member/MemberClassification.java
@@ -1,5 +1,5 @@
 package ProjectDoge.StudentSoup.entity.member;
 
 public enum MemberClassification {
-    STUDENT, STOREOWNER, PROFESSOR
+    STUDENT, STOREOWNER, PROFESSOR, ADMIN
 }

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/exception/restaurant/RestaurantReviewNotOwnException.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/exception/restaurant/RestaurantReviewNotOwnException.java
@@ -1,0 +1,24 @@
+package ProjectDoge.StudentSoup.exception.restaurant;
+
+public class RestaurantReviewNotOwnException extends RuntimeException {
+
+    public RestaurantReviewNotOwnException() {
+        super();
+    }
+
+    public RestaurantReviewNotOwnException(String message) {
+        super(message);
+    }
+
+    public RestaurantReviewNotOwnException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public RestaurantReviewNotOwnException(Throwable cause) {
+        super(cause);
+    }
+
+    protected RestaurantReviewNotOwnException(String message, Throwable cause, boolean enableSuppression, boolean writableStackTrace) {
+        super(message, cause, enableSuppression, writableStackTrace);
+    }
+}

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/exhandler/advice/RestaurantReviewAdvice.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/exhandler/advice/RestaurantReviewAdvice.java
@@ -2,6 +2,7 @@ package ProjectDoge.StudentSoup.exhandler.advice;
 
 import ProjectDoge.StudentSoup.exception.restaurant.RestaurantMenuIdNotSentException;
 import ProjectDoge.StudentSoup.exception.restaurant.RestaurantReviewIdNotSentException;
+import ProjectDoge.StudentSoup.exception.restaurant.RestaurantReviewNotOwnException;
 import ProjectDoge.StudentSoup.exhandler.ErrorResult;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -18,5 +19,12 @@ public class RestaurantReviewAdvice {
     public ErrorResult restaurantReviewIdNotSentHandler(RestaurantReviewIdNotSentException e){
         log.error("[exceptionHandle] ex", e);
         return new ErrorResult("RestaurantReviewIdNotSent",e.getMessage());
+    }
+
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @ExceptionHandler(RestaurantReviewNotOwnException.class)
+    public ErrorResult restaurantReviewNotOwnHandler(RestaurantReviewNotOwnException e){
+        log.error("[exceptionHandle] ex", e);
+        return new ErrorResult("RestaurantReviewNotOwn",e.getMessage());
     }
 }

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/repository/board/BoardRepositoryImpl.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/repository/board/BoardRepositoryImpl.java
@@ -1,7 +1,5 @@
 package ProjectDoge.StudentSoup.repository.board;
 
-
-
 import ProjectDoge.StudentSoup.dto.board.BoardMainDto;
 import ProjectDoge.StudentSoup.dto.board.BoardSortedCase;
 import ProjectDoge.StudentSoup.dto.board.QBoardMainDto;
@@ -16,9 +14,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.support.PageableExecutionUtils;
 
-import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.time.LocalTime;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.Optional;

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/service/restaurantreview/RestaurantReviewDeleteService.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/service/restaurantreview/RestaurantReviewDeleteService.java
@@ -1,0 +1,43 @@
+package ProjectDoge.StudentSoup.service.restaurantreview;
+
+import ProjectDoge.StudentSoup.entity.member.MemberClassification;
+import ProjectDoge.StudentSoup.entity.restaurant.RestaurantReview;
+import ProjectDoge.StudentSoup.exception.member.MemberNotFoundException;
+import ProjectDoge.StudentSoup.exception.restaurant.RestaurantReviewNotOwnException;
+import ProjectDoge.StudentSoup.repository.restaurantreview.RestaurantReviewRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import javax.transaction.Transactional;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class RestaurantReviewDeleteService {
+
+    private final RestaurantReviewFindService restaurantReviewFindService;
+    private final RestaurantReviewRepository restaurantReviewRepository;
+
+    @Transactional
+    public ConcurrentHashMap<String, String> deleteRestaurantReview(Long restaurantReviewId, Long memberId){
+        checkLoginStatus(memberId);
+        ConcurrentHashMap<String, String> resultMap = new ConcurrentHashMap<>();
+        RestaurantReview findRestaurantReview = restaurantReviewFindService.findOne(restaurantReviewId);
+        if(!findRestaurantReview.getMember().getMemberId().equals(memberId) || findRestaurantReview.getMember().getMemberClassification() != MemberClassification.ADMIN){
+            throw new RestaurantReviewNotOwnException("해당 리뷰는 해당 회원이 작성한 리뷰가 아닙니다.");
+        }
+        restaurantReviewRepository.delete(findRestaurantReview);
+        resultMap.put("result", "ok");
+        return resultMap;
+    }
+
+    private void checkLoginStatus(Long memberId){
+        log.info("회원의 로그인 상태를 확인합니다. [{}]", memberId);
+        if(memberId == null){
+            throw new MemberNotFoundException("기본키가 전달되지 않았거나, 로그인 되지 않은 상태에서 리뷰 삭제는 불가능합니다.");
+        }
+        log.info("회원의 로그인 상태 확인이 완료되었습니다.");
+    }
+}

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/service/restaurantreview/RestaurantReviewDeleteService.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/service/restaurantreview/RestaurantReviewDeleteService.java
@@ -25,7 +25,7 @@ public class RestaurantReviewDeleteService {
         checkLoginStatus(memberId);
         ConcurrentHashMap<String, String> resultMap = new ConcurrentHashMap<>();
         RestaurantReview findRestaurantReview = restaurantReviewFindService.findOne(restaurantReviewId);
-        if(!findRestaurantReview.getMember().getMemberId().equals(memberId) || findRestaurantReview.getMember().getMemberClassification() != MemberClassification.ADMIN){
+        if(!findRestaurantReview.getMember().getMemberId().equals(memberId) && findRestaurantReview.getMember().getMemberClassification() != MemberClassification.ADMIN){
             throw new RestaurantReviewNotOwnException("해당 리뷰는 해당 회원이 작성한 리뷰가 아닙니다.");
         }
         restaurantReviewRepository.delete(findRestaurantReview);


### PR DESCRIPTION
## 1. Changes
- 음식점 리뷰 삭제 시 본인의 것이 아닐 경우에 대한 예외 추가
- 회원 분류에 운영자 추가
- 음식점 리뷰 삭제 서비스 로직 추가
- 음식점 삭제 요청 dto 추가

## 2. Screenshot

-

## 3. Issues

1. 
2. 

## 4. To Reviewer

- @Trophy198 음식점 리뷰 삭제 시에 리뷰가 현재 로그인 한 회원 ID와 다르거나, 로그인이 되어있지 않으면 리뷰 수정 및 리뷰 삭제 탭이 노출되어서는 안됩니다. `if(memberId == null || 해당 restaurantReview의 memberId != memberId)` 일 경우 리뷰 수정 및 리뷰 삭제 탭이 노출되지 않게 해주세요 

## 5. Plans
