### PR TITLE
mjw/callResponseImage

### DIFF
--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/controller/image/ImageResponseController.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/controller/image/ImageResponseController.java
@@ -1,0 +1,27 @@
+package ProjectDoge.StudentSoup.controller.image;
+
+import ProjectDoge.StudentSoup.service.file.FileService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.UrlResource;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.net.MalformedURLException;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+
+public class ImageResponseController {
+
+    private final FileService fileService;
+
+    @GetMapping("/image/{fileName}")
+    public Resource responseImage(@PathVariable String fileName) throws MalformedURLException {
+        log.info("이미지 호출이 시작되었습니다. 해당 이미지의 이름 : [{}], 저장 위치 : [{}]", fileName, fileService.getFullPath(fileName));
+        return new UrlResource("file:" + fileService.getFullPath(fileName));
+    }
+}


### PR DESCRIPTION
## 1. Changes

- 이미지를 호출하는 api를 추가하였습니다.

## 2. Screenshot

-

## 3. Issues

1. 
2. 

## 4. To Reviewer

- image 호출 시 이미지가 1개 일 경우가 있고, 해당 이미지가 여러 개일 경우가 있습니다. 이미지 호출 시에 이미지 개수는 보내드리는 이미지 list의 사이즈로 판별이 가능합니다. 추가적으로 이미지를 호출 할 때는 보내드리는 응답 페이지의 이미지 사이즈 개수 만큼 api를 호출하면 됩니다.

## 5. Plans
- [ ] - 
- [ ] - 
