### PR TITLE
mjw/detachRestaurantMenu

### DIFF
--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/controller/restaurant/RestaurantDetailCallController.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/controller/restaurant/RestaurantDetailCallController.java
@@ -2,9 +2,13 @@ package ProjectDoge.StudentSoup.controller.restaurant;
 
 
 import ProjectDoge.StudentSoup.dto.restaurant.RestaurantDetailRequestDto;
+import ProjectDoge.StudentSoup.dto.restaurantmenu.RestaurantMenuDto;
+import ProjectDoge.StudentSoup.dto.restaurantmenu.RestaurantMenuRequestDto;
 import ProjectDoge.StudentSoup.service.restaurant.RestaurantDetailCallService;
+import ProjectDoge.StudentSoup.service.restaurantmenu.RestaurantMenuCallService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.web.bind.annotation.*;
@@ -18,11 +22,18 @@ import java.util.concurrent.ConcurrentHashMap;
 public class RestaurantDetailCallController {
 
     private final RestaurantDetailCallService restaurantDetailCallService;
+    private final RestaurantMenuCallService restaurantMenuCallService;
 
     @PostMapping("/{restaurantId}")
     public ConcurrentHashMap<String, Object> callRestaurantDetail(@PathVariable Long restaurantId,
-                                                                  @RequestBody RestaurantDetailRequestDto dto,
-                                                                  @PageableDefault(size = 4) Pageable pageable){
-        return restaurantDetailCallService.restaurantDetailCall(dto.getRestaurantId(), dto.getMemberId(), pageable);
+                                                                  @RequestBody RestaurantDetailRequestDto dto){
+        return restaurantDetailCallService.restaurantDetailCall(dto.getRestaurantId(), dto.getMemberId());
+    }
+
+    @PostMapping("/{restaurantId}/menus")
+    public Page<RestaurantMenuDto> callRestaurantMenu(@PathVariable Long restaurantId,
+                                                      @RequestBody RestaurantMenuRequestDto dto,
+                                                      @PageableDefault(size = 4) Pageable pageable){
+        return restaurantMenuCallService.restaurantMenuCall(dto.getRestaurantId(), dto.getMemberId(), pageable);
     }
 }

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/controller/restaurant/RestaurantDetailCallController.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/controller/restaurant/RestaurantDetailCallController.java
@@ -2,7 +2,7 @@ package ProjectDoge.StudentSoup.controller.restaurant;
 
 
 import ProjectDoge.StudentSoup.dto.restaurant.RestaurantDetailRequestDto;
-import ProjectDoge.StudentSoup.service.restaurantmenu.RestaurantMenuCallService;
+import ProjectDoge.StudentSoup.service.restaurant.RestaurantDetailCallService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Pageable;
@@ -17,12 +17,12 @@ import java.util.concurrent.ConcurrentHashMap;
 @RestController
 public class RestaurantDetailCallController {
 
-    private final RestaurantMenuCallService restaurantMenuCallService;
+    private final RestaurantDetailCallService restaurantDetailCallService;
 
     @PostMapping("/{restaurantId}")
     public ConcurrentHashMap<String, Object> callRestaurantDetail(@PathVariable Long restaurantId,
                                                                   @RequestBody RestaurantDetailRequestDto dto,
                                                                   @PageableDefault(size = 4) Pageable pageable){
-        return restaurantMenuCallService.restaurantDetailCall(dto.getRestaurantId(), dto.getMemberId(), pageable);
+        return restaurantDetailCallService.restaurantDetailCall(dto.getRestaurantId(), dto.getMemberId(), pageable);
     }
 }

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/dto/restaurantmenu/RestaurantMenuRequestDto.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/dto/restaurantmenu/RestaurantMenuRequestDto.java
@@ -1,0 +1,9 @@
+package ProjectDoge.StudentSoup.dto.restaurantmenu;
+
+import lombok.Data;
+
+@Data
+public class RestaurantMenuRequestDto {
+    private Long restaurantId;
+    private Long memberId;
+}

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/entity/restaurant/RestaurantMenu.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/entity/restaurant/RestaurantMenu.java
@@ -7,6 +7,8 @@ import lombok.Getter;
 import lombok.Setter;
 
 import javax.persistence.*;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Table(name = "RESTAURANT_MENU")
@@ -33,6 +35,9 @@ public class RestaurantMenu {
     private ImageFile imageFile;
 
     private int likedCount;
+
+    @OneToMany(mappedBy = "restaurantMenu", cascade = CascadeType.REMOVE)
+    private List<RestaurantMenuLike> restaurantMenuLikes = new ArrayList<>();
 
     //== 연관관계 메서드 ==//
     public void setRestaurant(Restaurant restaurant){

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/service/restaurant/RestaurantCallService.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/service/restaurant/RestaurantCallService.java
@@ -6,13 +6,11 @@ import ProjectDoge.StudentSoup.dto.school.SchoolResponseDto;
 import ProjectDoge.StudentSoup.entity.restaurant.Restaurant;
 import ProjectDoge.StudentSoup.entity.restaurant.RestaurantLike;
 import ProjectDoge.StudentSoup.entity.school.School;
-import ProjectDoge.StudentSoup.repository.restaurant.RestaurantLikeRepository;
 import ProjectDoge.StudentSoup.repository.restaurant.RestaurantRepository;
 import ProjectDoge.StudentSoup.service.school.SchoolFindService;
 import com.querydsl.jpa.impl.JPAQuery;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.support.PageableExecutionUtils;
@@ -28,7 +26,6 @@ import java.util.concurrent.ConcurrentHashMap;
 public class RestaurantCallService {
 
     private final RestaurantRepository restaurantRepository;
-    private final RestaurantLikeRepository restaurantLikeRepository;
     private final SchoolFindService schoolFindService;
 
     boolean restaurantLiked = true;

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/service/restaurant/RestaurantDetailCallService.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/service/restaurant/RestaurantDetailCallService.java
@@ -1,4 +1,4 @@
-package ProjectDoge.StudentSoup.service.restaurantmenu;
+package ProjectDoge.StudentSoup.service.restaurant;
 
 import ProjectDoge.StudentSoup.dto.restaurant.RestaurantDetailDto;
 import ProjectDoge.StudentSoup.dto.restaurantmenu.RestaurantMenuDto;
@@ -26,7 +26,7 @@ import java.util.concurrent.ConcurrentHashMap;
 @Slf4j
 @Service
 @RequiredArgsConstructor
-public class RestaurantMenuCallService {
+public class RestaurantDetailCallService {
     private final RestaurantFindService restaurantFindService;
     private final RestaurantLikeRepository restaurantLikeRepository;
     private final RestaurantMenuRepository restaurantMenuRepository;

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/service/restaurant/RestaurantDetailCallService.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/service/restaurant/RestaurantDetailCallService.java
@@ -29,18 +29,16 @@ import java.util.concurrent.ConcurrentHashMap;
 public class RestaurantDetailCallService {
     private final RestaurantFindService restaurantFindService;
     private final RestaurantLikeRepository restaurantLikeRepository;
-    private final RestaurantMenuRepository restaurantMenuRepository;
 
     private final boolean LIKED = true;
     private final boolean NOT_LIKED = false;
 
     @Transactional
-    public ConcurrentHashMap<String, Object> restaurantDetailCall(Long restaurantId, Long memberId, Pageable pageable){
+    public ConcurrentHashMap<String, Object> restaurantDetailCall(Long restaurantId, Long memberId){
 
         log.info("음식점 세부사항 호출 로직이 실행되었습니다. [{}]", restaurantId);
 
         ConcurrentHashMap<String, Object> resultMap = new ConcurrentHashMap<>();
-        JPAQuery<Long> count = restaurantMenuRepository.countByRestaurantId(restaurantId);
         Restaurant restaurant = restaurantFindService.findOne(restaurantId);
         setRestaurantDetailInfo(restaurantId, memberId, resultMap, restaurant);
         log.info("음식점 세부사항 호출 로직이 완료되었습니다.");

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/service/restaurantmenu/RestaurantMenuCallService.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/service/restaurantmenu/RestaurantMenuCallService.java
@@ -1,0 +1,94 @@
+package ProjectDoge.StudentSoup.service.restaurantmenu;
+
+import ProjectDoge.StudentSoup.dto.restaurantmenu.RestaurantMenuDto;
+import ProjectDoge.StudentSoup.entity.restaurant.RestaurantMenu;
+import ProjectDoge.StudentSoup.entity.restaurant.RestaurantMenuLike;
+import ProjectDoge.StudentSoup.repository.restaurantmenu.RestaurantMenuRepository;
+import com.querydsl.jpa.impl.JPAQuery;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.support.PageableExecutionUtils;
+import org.springframework.stereotype.Service;
+
+import javax.transaction.Transactional;
+import java.util.ArrayList;
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class RestaurantMenuCallService {
+
+    private final RestaurantMenuRepository restaurantMenuRepository;
+
+    private final boolean LIKED = true;
+    private final boolean NOT_LIKED = false;
+
+    @Transactional
+    public Page<RestaurantMenuDto> restaurantMenuCall(Long restaurantId, Long memberId, Pageable pageable){
+        log.info("음식점 메뉴 호출이 실행되었습니다. [{}]", restaurantId);
+        JPAQuery<Long> count = restaurantMenuRepository.countByRestaurantId(restaurantId);
+        Page<RestaurantMenuDto> restaurantMenuDtoList = setRestaurantMenuInfo(restaurantId, memberId, pageable, count);
+        log.info("음식점 메뉴 호출이 완료되었습니다.");
+        return restaurantMenuDtoList;
+    }
+
+    private Page<RestaurantMenuDto> setRestaurantMenuInfo(Long restaurantId, Long memberId, Pageable pageable, JPAQuery<Long> count) {
+        if(isLoginMember(memberId)){
+            return setLoginStatusRestaurantMenu(restaurantId, memberId, pageable, count);
+        }
+        return setNotLoginStatusRestaurantMenu(restaurantId, pageable, count);
+    }
+
+    private boolean isLoginMember(Long memberId) {
+        return memberId != null;
+    }
+
+    private Page<RestaurantMenuDto> setLoginStatusRestaurantMenu(Long restaurantId,
+                                                                 Long memberId,
+                                                                 Pageable pageable,
+                                                                 JPAQuery<Long> count){
+        log.info("회원이 로그인 된 상태에서의 음식점 메뉴 호출이 실행되었습니다.");
+        List<RestaurantMenuDto> restaurantMenuDtoList = new ArrayList<>();
+        List<RestaurantMenu> restaurantMenuList = restaurantMenuRepository.findByRestaurantId(restaurantId, pageable);
+        for(RestaurantMenu restaurantMenu : restaurantMenuList){
+            restaurantMenuDtoList.add(getLoginStatusRestaurantMenuDto(memberId, restaurantMenu));
+        }
+
+        return PageableExecutionUtils.getPage(restaurantMenuDtoList, pageable, count::fetchOne);
+    }
+
+    private Page<RestaurantMenuDto> setNotLoginStatusRestaurantMenu(Long restaurantId,
+                                                                    Pageable pageable,
+                                                                    JPAQuery<Long> count){
+        log.info("회원이 로그인 되지 않은 상태에서의 음식점 메뉴 호출이 실행되었습니다.");
+        List<RestaurantMenuDto> restaurantMenuDtoList = new ArrayList<>();
+        List<RestaurantMenu> restaurantMenuList = restaurantMenuRepository.findByRestaurantId(restaurantId, pageable);
+        for(RestaurantMenu restaurantMenu : restaurantMenuList){
+            restaurantMenuDtoList.add(getNotLoginStatusRestaurantMenuDto(restaurantMenu));
+        }
+        return PageableExecutionUtils.getPage(restaurantMenuDtoList, pageable, count::fetchOne);
+    }
+
+    private RestaurantMenuDto getLoginStatusRestaurantMenuDto(Long memberId, RestaurantMenu restaurantMenu){
+        for (RestaurantMenuLike restaurantMenuLike : restaurantMenu.getRestaurantMenuLikes()){
+            if (restaurantMenuLike.getMember().getMemberId().equals(memberId))
+                return getLikeRestaurantMenuDto(restaurantMenu);
+        }
+        return getNotLikeRestaurantMenuDto(restaurantMenu);
+    }
+
+    private RestaurantMenuDto getNotLoginStatusRestaurantMenuDto(RestaurantMenu restaurantMenu){
+        return getNotLikeRestaurantMenuDto(restaurantMenu);
+    }
+
+    private RestaurantMenuDto getNotLikeRestaurantMenuDto(RestaurantMenu restaurantMenu){
+        return new RestaurantMenuDto().createRestaurantMenu(restaurantMenu, NOT_LIKED);
+    }
+
+    private RestaurantMenuDto getLikeRestaurantMenuDto(RestaurantMenu restaurantMenu){
+        return new RestaurantMenuDto().createRestaurantMenu(restaurantMenu, LIKED);
+    }
+}


### PR DESCRIPTION
## 1. Changes
- 음식점 메뉴 호출과 음식점 세부 페이지 호출에 대한 api를 분리하였습니다.

## 2. Screenshot

-

## 3. Issues

1. 음식점의 세부사항과 메뉴를 호출하는 부분에 대한 api를 동일하게 가져가다보니 여러 서비스 로직이 겹치는 문제가 있었습니다.
대표적으로 `viewCount`가 여러 번 올라가는 문제가 있었는데, 해당 문제를 해결하기 위하여 **menu 호출과 세부 페이지 호출에 대한 api를 분리**하였습니다.
2. 

## 4. To Reviewer

-

## 5. Plans
