### PR TITLE
mjw/fixAdminRestaurantPage

### DIFF
--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/dto/restaurant/RestaurantFormDto.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/dto/restaurant/RestaurantFormDto.java
@@ -35,7 +35,7 @@ public class RestaurantFormDto {
 
     private String coordinate;
 
-    private List<MultipartFile> multiparFileList;
+    private List<MultipartFile> multipartFileList;
 
     @NotEmpty(message = "가게번호 입력은 필수 입니다.")
     private String tel;

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/entity/file/ImageFile.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/entity/file/ImageFile.java
@@ -41,17 +41,14 @@ public class ImageFile {
     //== 연관관계 메서드 ==//
     public void setBoard(Board board){
         this.board = board;
-        board.getImageFiles().add(this);
     }
 
     public void setRestaurantReview(RestaurantReview restaurantReview){
         this.restaurantReview = restaurantReview;
-        restaurantReview.getImageFileList().add(this);
     }
 
     public void setRestaurant(Restaurant restaurant){
         this.restaurant = restaurant;
-        restaurant.getImageFileList().add(this);
     }
 
 

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/entity/restaurant/Restaurant.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/entity/restaurant/Restaurant.java
@@ -43,7 +43,7 @@ public class Restaurant {
 
     private int distance;
 
-    @OneToMany(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    @OneToMany(fetch = FetchType.LAZY)
     private List<ImageFile> imageFileList = new ArrayList<>();
 
     private int viewCount;
@@ -169,10 +169,10 @@ public class Restaurant {
     
     // 이미지 추가 로직
     public void addImageFile(ImageFile imageFile) {
-        this.getImageFileList().add(imageFile);
-
         if (imageFile.getRestaurant() != this)
             imageFile.setRestaurant(this);
+
+        this.getImageFileList().add(imageFile);
     }
 
     // 별점 업데이트 로직

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/entity/restaurant/RestaurantReview.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/entity/restaurant/RestaurantReview.java
@@ -33,7 +33,6 @@ public class RestaurantReview {
 
     private String content;
 
-
     @OneToMany(mappedBy = "restaurantReview")
     private List<ImageFile> imageFileList = new ArrayList<>();
 
@@ -91,10 +90,10 @@ public class RestaurantReview {
 
     //== 비즈니스 로직 ==//
     public void addImageFile(ImageFile imageFile){
-        this.getImageFileList().add(imageFile);
-
         if(imageFile.getRestaurantReview() != this)
             imageFile.setRestaurantReview(this);
+
+        this.getImageFileList().add(imageFile);
     }
 
     public void addLikedCount(){

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/service/restaurant/RestaurantRegisterService.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/service/restaurant/RestaurantRegisterService.java
@@ -4,7 +4,6 @@ import ProjectDoge.StudentSoup.dto.file.UploadFileDto;
 import ProjectDoge.StudentSoup.dto.restaurant.RestaurantFormDto;
 import ProjectDoge.StudentSoup.entity.file.ImageFile;
 import ProjectDoge.StudentSoup.entity.restaurant.Restaurant;
-import ProjectDoge.StudentSoup.entity.restaurant.RestaurantReview;
 import ProjectDoge.StudentSoup.entity.school.School;
 import ProjectDoge.StudentSoup.repository.file.FileRepository;
 import ProjectDoge.StudentSoup.repository.restaurant.RestaurantRepository;
@@ -29,15 +28,15 @@ public class RestaurantRegisterService {
 
     private final RestaurantRepository restaurantRepository;
 
-    @Transactional
+    @Transactional(rollbackFor = Exception.class)
     public Long join(RestaurantFormDto dto) {
         log.info("음식점 생성 메서드가 실행되었습니다.");
         School school = schoolFindService.findOne(dto.getSchoolId());
         Restaurant restaurant = new Restaurant().createRestaurant(dto,school);
-        List<UploadFileDto> uploadFileDtoList = fileService.createUploadFileDtoList(dto.getMultiparFileList());
-        uploadRestaurantImage(restaurant, uploadFileDtoList);
         restaurant.setDistance(restaurant.calcDistance(school));
         restaurantValidationService.validateDuplicateRestaurant(restaurant);
+        List<UploadFileDto> uploadFileDtoList = fileService.createUploadFileDtoList(dto.getMultipartFileList());
+        uploadRestaurantImage(restaurant, uploadFileDtoList);
         restaurantRepository.save(restaurant);
         log.info("음식점이 생성되었습니다.[{}][{}]",restaurant.getId(), restaurant.getName(), restaurant.getDistance());
         return restaurant.getId();
@@ -52,7 +51,7 @@ public class RestaurantRegisterService {
                 restaurant.addImageFile(fileRepository.save(imageFile));
             }
         }
-        log.info("음식점 리뷰 이미지 업로드가 완료되었습니다.");
+        log.info("음식점 이미지 업로드가 완료되었습니다.");
     }
 
     @Transactional

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/service/restaurantreview/RestaurantReviewRegisterService.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/service/restaurantreview/RestaurantReviewRegisterService.java
@@ -17,8 +17,8 @@ import ProjectDoge.StudentSoup.service.restaurant.RestaurantFindService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
-import javax.transaction.Transactional;
 import java.util.List;
 
 @Slf4j
@@ -32,7 +32,7 @@ public class RestaurantReviewRegisterService {
     private final FileRepository fileRepository;
     private final FileService fileService;
 
-    @Transactional(rollbackOn = Exception.class)
+    @Transactional(rollbackFor = Exception.class)
     public Long join(RestaurantReviewRequestDto dto){
         log.info("음식점 리뷰 등록 서비스가 실행되었습니다.");
         checkReviewDto(dto);
@@ -84,7 +84,7 @@ public class RestaurantReviewRegisterService {
         log.info("음식점 리뷰 이미지 업로드가 완료되었습니다.");
     }
 
-    @Transactional(rollbackOn = Exception.class)
+    @Transactional(rollbackFor = Exception.class)
     public RestaurantReviewRegRespDto starUpdate(Long restaurantId){
         Restaurant restaurant = restaurantFindService.findOne(restaurantId);
         log.info("레스토랑의 업데이트 전 별점 : [{}]", restaurant.getStarLiked());

--- a/StudentSoup/src/main/resources/templates/admin/restaurant/createRestaurant.html
+++ b/StudentSoup/src/main/resources/templates/admin/restaurant/createRestaurant.html
@@ -136,8 +136,9 @@
                                                                 </div>
                                                                 <div class="col-md-7 pe-5">
                                                                     <input type="file"
+                                                                           multiple="multiple"
                                                                            class="form-control form-control-sm"
-                                                                           name="multipartFile">
+                                                                           name="multipartFileList">
                                                                     <div class="small text-muted mt-2">Upload your
                                                                         profile Image.
                                                                         Max file size 10MB

--- a/StudentSoup/src/main/resources/templates/admin/restaurant/restaurantList.html
+++ b/StudentSoup/src/main/resources/templates/admin/restaurant/restaurantList.html
@@ -47,11 +47,14 @@
                             <td th:text="${restaurant.tel}">tel</td>
                             <td th:text="${restaurant.tag}">tag</td>
                             <td th:text="${restaurant.detail}">detail</td>
-                            <td th:if="${restaurant.imageFile != null}"
-                                th:text="${ restaurant.imageFile.fileOriginalName}">
-                                fileName
+                            <td th:if="${restaurant.imageFileList.size() != 0}">
+                                <p
+                                   th:each="imageFile : ${restaurant.imageFileList}"
+                                    th:text="${imageFile.getFileName()} + ','">
+                                    text
+                                </p>
                             </td>
-                            <td th:if="${restaurant.imageFile == null}">null</td>
+                            <td th:if="${restaurant.imageFileList.size() == 0}">null</td>
                             <td th:text="${restaurant.starLiked}">starLiked</td>
                             <td th:text="${restaurant.likedCount}">likedCount</td>
                             <td>
@@ -132,11 +135,11 @@
                         <td th:text="${findRestaurants.tel}">tel</td>
                         <td th:text="${findRestaurants.tag}">tag</td>
                         <td th:text="${findRestaurants.detail}">detail</td>
-                        <td th:if="${findRestaurants.imageFile != null}"
+                        <td th:if="${findRestaurants.imageFileList.size() != 0}" th:each="imageFile : ${restaurant.imageFileList}"
                             th:text="${findRestaurants.imageFile.fileOriginalName}">
                             fileName
                         </td>
-                        <td th:if="${findRestaurants.imageFile == null}">null</td>
+                        <td th:if="${findRestaurants.imageFileList.size() == 0}">null</td>
                         <td th:text="${findRestaurants.starLiked}">starLiked</td>
                         <td th:text="${findRestaurants.likedCount}">likedCount</td>
                         <td>

--- a/StudentSoup/src/main/resources/templates/admin/restaurant/restaurantMenuList.html
+++ b/StudentSoup/src/main/resources/templates/admin/restaurant/restaurantMenuList.html
@@ -41,7 +41,6 @@
                                 fileName
                             </td>
                             <td th:if="${restaurantMenu.imageFile == null}">null</td>
-                            <td th:text="${restaurantMenu.starLiked}">starLiked</td>
                             <td th:text="${restaurantMenu.likedCount}">likedCount</td>
                             <td>
                                 <a th:href="@{/admin/restaurantMenu/edit/{restaurantMenuId}(restaurantMenuId = ${restaurantMenu.id})}">


### PR DESCRIPTION
## 1. Changes
- 음식점 등록 시 음식점 사진을 여러 개 등록할 수 있도록 수정하였습니다.

## 2. Screenshot

-

## 3. Issues

1. 해당 이슈를 손 보면서 많은 문제들이 있었습니다. 
먼저 @xogns4909 님이 작성하신 서비스 로직에서 `ImageFile`을 생성하고 검증을 하는 단계에서 `Proxy에 담긴 엔티티`와, `저장소에서 불러온 엔티티`의 상태가 달라서 검증 시 오류가 발생하는 문제가 있었습니다. 따라서 생성하고자 하는 음식점이 생성될 때 이미지를 담아오기 전 검증하도록 서비스 로직을 수정하였습니다.
2. 가장 중요한 `연관관계 문제` 였습니다. `JPA`에서 연관관계를 설정할 때에는 `한 곳에서 2중으로 설정해주는 것이 원칙`입니다. 그래야 **객체지향적으로 봤을 때 주입 받는 객체가 그 상태를 알 수 있기 때문**입니다. 그러나 연관관계를 설정하면서 `두 개의 엔티티에 2중`으로 설정을 하게 되면서 **기본키가 중복되서 생성되게 되는 문제**가 있었습니다.
3. 마지막으로 `@Transactional`의 `rollBackFor` 파라미터 관련 내용입니다. 기존에 `@Transactional`을 사용하면서 `rollbackFor`가 사용이 안되고 `rollbackOn`만 사용이 되길래, `deprecated` 된 줄 알았고.. `stackoverflow`에도 동일하게 쓰여있었기에 **의심없이 사용했지만** 알고보니 `@Transactional` 인터페이스를 구현하는 라이브러리가 `javax`, `springframework` **두 곳에서 구현**을 하고 있었습니다. `springframework`는 기존과 동일하게 `rollBackFor`를 **사용**합니다. 
**요즘에는 잘못된 정보가 너무 많아 정보를 찾을 때에는 무조건 공식문서를 찾아보는 습관이 중요한 것 같습니다.**

## 4. To Reviewer

-

## 5. Plans
