### PR TITLE
mjw/fixCreateRestaurantReviewNotMatch

### DIFF
--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/controller/restaurantreview/RestaurantReviewRegisterController.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/controller/restaurantreview/RestaurantReviewRegisterController.java
@@ -28,7 +28,7 @@ public class RestaurantReviewRegisterController {
                                                                                       RestaurantReviewRequestDto dto){
 
         ConcurrentHashMap<String, Object> resultMap = new ConcurrentHashMap<>();
-        restaurantReviewRegisterService.join(dto);
+        restaurantReviewRegisterService.join(restaurantId, dto);
         RestaurantReviewRegRespDto respDto = restaurantReviewRegisterService.starUpdate(restaurantId);
 
         resultMap.put("data", respDto);

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/dto/restaurantreview/RestaurantReviewRequestDto.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/dto/restaurantreview/RestaurantReviewRequestDto.java
@@ -7,7 +7,6 @@ import java.util.List;
 
 @Data
 public class RestaurantReviewRequestDto {
-    private Long restaurantId;
     private String restaurantName;
     private Long memberId;
     private String nickName;

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/exception/restaurant/RestaurantNotMatchException.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/exception/restaurant/RestaurantNotMatchException.java
@@ -1,0 +1,23 @@
+package ProjectDoge.StudentSoup.exception.restaurant;
+
+public class RestaurantNotMatchException extends RuntimeException {
+    public RestaurantNotMatchException() {
+        super();
+    }
+
+    public RestaurantNotMatchException(String message) {
+        super(message);
+    }
+
+    public RestaurantNotMatchException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public RestaurantNotMatchException(Throwable cause) {
+        super(cause);
+    }
+
+    protected RestaurantNotMatchException(String message, Throwable cause, boolean enableSuppression, boolean writableStackTrace) {
+        super(message, cause, enableSuppression, writableStackTrace);
+    }
+}

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/exhandler/advice/RestaurantAdvice.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/exhandler/advice/RestaurantAdvice.java
@@ -39,4 +39,11 @@ public class RestaurantAdvice {
         log.error("[exceptionHandle] ex", e);
         return new ErrorResult("RestaurantIdNotSent", e.getMessage());
     }
+
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @ExceptionHandler(RestaurantNotMatchException.class)
+    public ErrorResult restaurantNotMatchHandler(RestaurantNotMatchException e){
+        log.error("[exceptionHandle] ex", e);
+        return new ErrorResult("RestaurantNotMatch", e.getMessage());
+    }
 }

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/init/TestDataInit.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/init/TestDataInit.java
@@ -279,27 +279,25 @@ public class TestDataInit {
         Member member = memberRepository.findByEmail("dummytest1@naver.com");
         for(int i = 0; i < 30; i++){
             RestaurantReviewRequestDto dto = new RestaurantReviewRequestDto();
-            dto.setRestaurantId(restaurant1.getId());
             dto.setRestaurantName(restaurant1.getName());
             dto.setMemberId(member.getMemberId());
             dto.setNickName(member.getNickname());
             dto.setContent((i + 1) + "번 째로 작성한 리뷰입니다.");
             dto.setStarLiked((int)(Math.random() * 5) + 1);
             dto.setMultipartFileList(Collections.emptyList());
-            restaurantReviewRegisterService.join(dto);
+            restaurantReviewRegisterService.join(restaurant1.getId(), dto);
             restaurantReviewRegisterService.starUpdate(restaurant1.getId());
         }
 
         for(int i = 0; i < 20; i++){
             RestaurantReviewRequestDto dto = new RestaurantReviewRequestDto();
-            dto.setRestaurantId(restaurant2.getId());
             dto.setRestaurantName(restaurant2.getName());
             dto.setMemberId(member.getMemberId());
             dto.setNickName(member.getNickname());
             dto.setContent((i + 1) + "번 째로 작성한 리뷰입니다.");
             dto.setStarLiked((int)(Math.random() * 5) + 1);
             dto.setMultipartFileList(Collections.emptyList());
-            restaurantReviewRegisterService.join(dto);
+            restaurantReviewRegisterService.join(restaurant2.getId(), dto);
             restaurantReviewRegisterService.starUpdate(restaurant2.getId());
         }
     }

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/service/restaurantreview/RestaurantReviewRegisterService.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/service/restaurantreview/RestaurantReviewRegisterService.java
@@ -7,6 +7,7 @@ import ProjectDoge.StudentSoup.entity.file.ImageFile;
 import ProjectDoge.StudentSoup.entity.member.Member;
 import ProjectDoge.StudentSoup.entity.restaurant.Restaurant;
 import ProjectDoge.StudentSoup.entity.restaurant.RestaurantReview;
+import ProjectDoge.StudentSoup.exception.restaurant.RestaurantNotMatchException;
 import ProjectDoge.StudentSoup.exception.restaurant.RestaurantReviewContentLessThanFiveException;
 import ProjectDoge.StudentSoup.exception.restaurant.RestaurantStarLikedMoreThanFiveException;
 import ProjectDoge.StudentSoup.repository.file.FileRepository;
@@ -20,6 +21,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Objects;
 
 @Slf4j
 @Service
@@ -33,10 +35,9 @@ public class RestaurantReviewRegisterService {
     private final FileService fileService;
 
     @Transactional(rollbackFor = Exception.class)
-    public Long join(RestaurantReviewRequestDto dto){
+    public Long join(Long restaurantId, RestaurantReviewRequestDto dto){
         log.info("음식점 리뷰 등록 서비스가 실행되었습니다.");
-        checkReviewDto(dto);
-        RestaurantReview restaurantReview = createRestaurantReview(dto);
+        RestaurantReview restaurantReview = createRestaurantReview(restaurantId, dto);
         List<UploadFileDto> uploadFileDtoList = fileService.createUploadFileDtoList(dto.getMultipartFileList());
         uploadRestaurantReviewImage(restaurantReview, uploadFileDtoList);
         RestaurantReview createdRestaurantReview = restaurantReviewRepository.save(restaurantReview);
@@ -44,32 +45,26 @@ public class RestaurantReviewRegisterService {
         return createdRestaurantReview.getId();
     }
 
-    private static void checkReviewDto(RestaurantReviewRequestDto dto) {
+    private RestaurantReview createRestaurantReview(Long restaurantId, RestaurantReviewRequestDto dto) {
+        log.info("음식점 리뷰 엔티티 생성 메소드가 실행 되었습니다.");
+        Restaurant restaurant = restaurantFindService.findOne(restaurantId);
+        checkReviewDto(dto, restaurant);
+
+        Member member = memberFindService.findOne(dto.getMemberId());
+        RestaurantReview restaurantReview = new RestaurantReview().createRestaurantReview(dto, restaurant, member);
+        log.info("음식점 리뷰 엔티티 생성 메소드가 완료 되었습니다. 닉네임 : [{}], 음식점 이름 : [{}]", dto.getNickName(), dto.getRestaurantName());
+        return restaurantReview;
+    }
+
+    private void checkReviewDto(RestaurantReviewRequestDto dto, Restaurant restaurant) {
+
         if(dto.getStarLiked() > 5){
             throw new RestaurantStarLikedMoreThanFiveException("별점은 5점을 초과할 수 없습니다.");
         } else if(dto.getContent().length() < 5){
             throw new RestaurantReviewContentLessThanFiveException("리뷰 작성 글은 5글자 이상이여야 합니다.");
+        } else if(!dto.getRestaurantName().equals(restaurant.getName())){
+            throw new RestaurantNotMatchException("잘못 된 음식점 호출입니다.");
         }
-    }
-
-    private RestaurantReviewRegRespDto restaurantRespDto(Long restaurantId, double star) {
-        log.info("리뷰 등록 응답 객체 생성을 시작하였습니다.");
-        RestaurantReviewRegRespDto dto = new RestaurantReviewRegRespDto();
-        dto.setRestaurantId(restaurantId);
-        dto.setStarLiked(star);
-        Long count = restaurantReviewRepository.countByRestaurantId(restaurantId);
-        dto.setReviewCount(count);
-        log.info("음식점 : [{}], 별점 : [{}], 리뷰 개수 : [{}]", restaurantId, star, count);
-        return dto;
-    }
-
-    private RestaurantReview createRestaurantReview(RestaurantReviewRequestDto dto) {
-        log.info("음식점 리뷰 엔티티 생성 메소드가 실행 되었습니다.");
-        Member member = memberFindService.findOne(dto.getMemberId());
-        Restaurant restaurant = restaurantFindService.findOne(dto.getRestaurantId());
-        RestaurantReview restaurantReview = new RestaurantReview().createRestaurantReview(dto, restaurant, member);
-        log.info("음식점 리뷰 엔티티 생성 메소드가 완료 되었습니다. 닉네임 : [{}], 음식점 이름 : [{}]", dto.getNickName(), dto.getRestaurantName());
-        return restaurantReview;
     }
 
     private void uploadRestaurantReviewImage(RestaurantReview restaurantReview, List<UploadFileDto> uploadFileDtoList) {
@@ -94,5 +89,16 @@ public class RestaurantReviewRegisterService {
         log.info("레스토랑의 업데이트 된 별점 : [{}] , 쿼리 결과 별점 : [{}]", restaurant.getStarLiked(), star);
 
         return restaurantRespDto(restaurantId, star);
+    }
+
+    private RestaurantReviewRegRespDto restaurantRespDto(Long restaurantId, double star) {
+        log.info("리뷰 등록 응답 객체 생성을 시작하였습니다.");
+        RestaurantReviewRegRespDto dto = new RestaurantReviewRegRespDto();
+        dto.setRestaurantId(restaurantId);
+        dto.setStarLiked(star);
+        Long count = restaurantReviewRepository.countByRestaurantId(restaurantId);
+        dto.setReviewCount(count);
+        log.info("음식점 : [{}], 별점 : [{}], 리뷰 개수 : [{}]", restaurantId, star, count);
+        return dto;
     }
 }


### PR DESCRIPTION
## 1. Changes
- 음식점 리뷰를 생성할 때, `Body` 와 `PathVariable` 이 일치하지 않는 경우에도 **음식점 리뷰가 생성되는 버그**를 해결하였습니다.

## 2. Screenshot

-

## 3. Issues

1. 기존에 음식점 리뷰 생성 시 `body` 를 기준으로 리뷰를 생성하게 해두었는데 이럴 경우 `PathVariable`과 `body`가 다를 경우에도 리뷰가 생성되는 문제를 확인할 수 있었습니다. 따라서 해당 예외를 추가하였고, 요청받는 `body` 데이터에서 겹치는 내용을 제거함으로써 해결하였습니다.
2. 

## 4. To Reviewer

-

## 5. Plans
