### PR TITLE
mjw/myPageCallService

### DIFF
--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/controller/member/MyPageCallController.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/controller/member/MyPageCallController.java
@@ -1,0 +1,55 @@
+package ProjectDoge.StudentSoup.controller.member;
+
+import ProjectDoge.StudentSoup.dto.member.MemberMyPageBoardDto;
+import ProjectDoge.StudentSoup.dto.member.MemberMyPageBoardReviewDto;
+import ProjectDoge.StudentSoup.dto.member.MemberMyPageDto;
+import ProjectDoge.StudentSoup.dto.member.MemberMyPageRestaurantReviewDto;
+import ProjectDoge.StudentSoup.service.member.MemberMyPageCallService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.web.bind.annotation.*;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/mypage")
+public class MyPageCallController {
+
+    private final MemberMyPageCallService memberMyPageCallService;
+
+    @GetMapping
+    public MemberMyPageDto callMyPageMain(@RequestBody Long memberId) {
+        return memberMyPageCallService.callMyPageMain(memberId);
+    }
+
+    @GetMapping("/detail")
+    public
+
+    @PostMapping("/board")
+    public Page<MemberMyPageBoardDto> callMyPageBoard(
+            @RequestBody Long memberId,
+            @PageableDefault(size = 6) Pageable pageable
+    ) {
+        return memberMyPageCallService.callMyPageBoard(memberId, pageable);
+    }
+
+    @PostMapping("/boardReview")
+    public Page<MemberMyPageBoardReviewDto> callMyPageBoardReview(
+            @RequestBody Long memberId,
+            @PageableDefault(size = 6) Pageable pageable
+    ) {
+        return memberMyPageCallService.callMyPageBoardReview(memberId, pageable);
+    }
+
+    @PostMapping("/restaurantReivew")
+    public Page<MemberMyPageRestaurantReviewDto> callMyPageRestaurantReview(
+            @RequestBody Long memberId,
+            @PageableDefault(size = 6) Pageable pageable,
+            @RequestParam("filter") String cond
+    ) {
+        return memberMyPageCallService.callMyRestaurantReview(memberId, cond, pageable);
+    }
+}

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/controller/member/MyPageCallController.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/controller/member/MyPageCallController.java
@@ -18,37 +18,41 @@ public class MyPageCallController {
     private final MemberMyPageCallService memberMyPageCallService;
 
     @GetMapping
-    public MemberMyPageDto callMyPageMain(@RequestBody Long memberId) {
-        return memberMyPageCallService.callMyPageMain(memberId);
+    public MemberMyPageDto callMyPageMain(@RequestBody MemberMyPageRequestDto dto) {
+        return memberMyPageCallService.callMyPageMain(dto.getMemberId());
     }
 
     @GetMapping("/detail")
-    public MemberMyPageDetailDto callMyPageDetail(@RequestBody Long memberId){
-        return memberMyPageCallService.callMyPageDetail(memberId);
+    public MemberMyPageDetailDto callMyPageDetail(@RequestBody MemberMyPageRequestDto dto){
+        return memberMyPageCallService.callMyPageDetail(dto.getMemberId());
     }
 
     @PostMapping("/board")
     public Page<MemberMyPageBoardDto> callMyPageBoard(
-            @RequestBody Long memberId,
+            @RequestBody MemberMyPageRequestDto dto,
             @PageableDefault(size = 6) Pageable pageable
     ) {
-        return memberMyPageCallService.callMyPageBoard(memberId, pageable);
+        return memberMyPageCallService.callMyPageBoard(dto.getMemberId(), pageable);
     }
 
     @PostMapping("/boardReview")
     public Page<MemberMyPageBoardReviewDto> callMyPageBoardReview(
-            @RequestBody Long memberId,
+            @RequestBody MemberMyPageRequestDto dto,
             @PageableDefault(size = 6) Pageable pageable
     ) {
-        return memberMyPageCallService.callMyPageBoardReview(memberId, pageable);
+        return memberMyPageCallService.callMyPageBoardReview(dto.getMemberId(), pageable);
     }
 
+    /**
+     *
+     * @param cond today(오늘), month(한달), halfYear(6개월), year(1년)
+     */
     @PostMapping("/restaurantReview")
     public Page<MemberMyPageRestaurantReviewDto> callMyPageRestaurantReview(
-            @RequestBody Long memberId,
+            @RequestBody MemberMyPageRequestDto dto,
             @PageableDefault(size = 6) Pageable pageable,
-            @RequestParam("filter") String cond
+            @RequestParam(value = "filter", required = false) String cond
     ) {
-        return memberMyPageCallService.callMyRestaurantReview(memberId, cond, pageable);
+        return memberMyPageCallService.callMyRestaurantReview(dto.getMemberId(), cond, pageable);
     }
 }

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/controller/member/MyPageCallController.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/controller/member/MyPageCallController.java
@@ -1,9 +1,6 @@
 package ProjectDoge.StudentSoup.controller.member;
 
-import ProjectDoge.StudentSoup.dto.member.MemberMyPageBoardDto;
-import ProjectDoge.StudentSoup.dto.member.MemberMyPageBoardReviewDto;
-import ProjectDoge.StudentSoup.dto.member.MemberMyPageDto;
-import ProjectDoge.StudentSoup.dto.member.MemberMyPageRestaurantReviewDto;
+import ProjectDoge.StudentSoup.dto.member.*;
 import ProjectDoge.StudentSoup.service.member.MemberMyPageCallService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -26,7 +23,9 @@ public class MyPageCallController {
     }
 
     @GetMapping("/detail")
-    public
+    public MemberMyPageDetailDto callMyPageDetail(@RequestBody Long memberId){
+        return memberMyPageCallService.callMyPageDetail(memberId);
+    }
 
     @PostMapping("/board")
     public Page<MemberMyPageBoardDto> callMyPageBoard(
@@ -44,7 +43,7 @@ public class MyPageCallController {
         return memberMyPageCallService.callMyPageBoardReview(memberId, pageable);
     }
 
-    @PostMapping("/restaurantReivew")
+    @PostMapping("/restaurantReview")
     public Page<MemberMyPageRestaurantReviewDto> callMyPageRestaurantReview(
             @RequestBody Long memberId,
             @PageableDefault(size = 6) Pageable pageable,

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/controller/member/ProfileUpdateController.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/controller/member/ProfileUpdateController.java
@@ -11,7 +11,7 @@ import org.springframework.web.multipart.MultipartFile;
 @Slf4j
 @RestController
 @RequiredArgsConstructor
-public class ProfileController {
+public class ProfileUpdateController {
 
     private final MemberProfileImageUpdateService memberProfileImageUpdateService;
 

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/dto/member/MemberMyPageBoardDto.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/dto/member/MemberMyPageBoardDto.java
@@ -1,7 +1,9 @@
 package ProjectDoge.StudentSoup.dto.member;
 
 import com.querydsl.core.annotations.QueryProjection;
+import lombok.Data;
 
+@Data
 public class MemberMyPageBoardDto {
 
     private Long boardId;

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/dto/member/MemberMyPageBoardDto.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/dto/member/MemberMyPageBoardDto.java
@@ -1,0 +1,23 @@
+package ProjectDoge.StudentSoup.dto.member;
+
+import com.querydsl.core.annotations.QueryProjection;
+
+public class MemberMyPageBoardDto {
+
+    private Long boardId;
+    private String writeDate;
+    private int likedCount;
+    private int viewCount;
+
+
+    public MemberMyPageBoardDto(){
+    }
+
+    @QueryProjection
+    public MemberMyPageBoardDto(Long boardId, String writeDate, int likedCount, int viewCount){
+        this.boardId = boardId;
+        this.writeDate = writeDate;
+        this.likedCount = likedCount;
+        this.viewCount = viewCount;
+    }
+}

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/dto/member/MemberMyPageBoardReviewDto.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/dto/member/MemberMyPageBoardReviewDto.java
@@ -10,6 +10,7 @@ import java.util.List;
 @Data
 public class MemberMyPageBoardReviewDto {
 
+    private Long boardId;
     private String content;
     private String writeDate;
     private int likedCount;
@@ -18,7 +19,8 @@ public class MemberMyPageBoardReviewDto {
     }
 
     @QueryProjection
-    public MemberMyPageBoardReviewDto(String content, String writeDate, int likedCount){
+    public MemberMyPageBoardReviewDto(Long boardId, String content, String writeDate, int likedCount){
+        this.boardId = boardId;
         this.content = content;
         this.writeDate = writeDate;
         this.likedCount = likedCount;

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/dto/member/MemberMyPageBoardReviewDto.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/dto/member/MemberMyPageBoardReviewDto.java
@@ -1,11 +1,8 @@
 package ProjectDoge.StudentSoup.dto.member;
 
-import ProjectDoge.StudentSoup.entity.board.QBoardReview;
-import com.querydsl.core.Tuple;
 import com.querydsl.core.annotations.QueryProjection;
 import lombok.Data;
 
-import java.util.List;
 
 @Data
 public class MemberMyPageBoardReviewDto {

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/dto/member/MemberMyPageBoardReviewDto.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/dto/member/MemberMyPageBoardReviewDto.java
@@ -1,0 +1,26 @@
+package ProjectDoge.StudentSoup.dto.member;
+
+import ProjectDoge.StudentSoup.entity.board.QBoardReview;
+import com.querydsl.core.Tuple;
+import com.querydsl.core.annotations.QueryProjection;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class MemberMyPageBoardReviewDto {
+
+    private String content;
+    private String writeDate;
+    private int likedCount;
+
+    public MemberMyPageBoardReviewDto(){
+    }
+
+    @QueryProjection
+    public MemberMyPageBoardReviewDto(String content, String writeDate, int likedCount){
+        this.content = content;
+        this.writeDate = writeDate;
+        this.likedCount = likedCount;
+    }
+}

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/dto/member/MemberMyPageDetailDto.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/dto/member/MemberMyPageDetailDto.java
@@ -1,5 +1,8 @@
 package ProjectDoge.StudentSoup.dto.member;
 
+import lombok.Data;
+
+@Data
 public class MemberMyPageDetailDto {
 
     private long boardWriteCount;

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/dto/member/MemberMyPageDetailDto.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/dto/member/MemberMyPageDetailDto.java
@@ -2,11 +2,11 @@ package ProjectDoge.StudentSoup.dto.member;
 
 public class MemberMyPageDetailDto {
 
-    private long boardViewCount;
-    private long boardReviewCount;
+    private long boardWriteCount;
+    private long boardReviewWriteCount;
 
-    public MemberMyPageDetailDto(long boardViewCount, long boardReviewCount){
-        this.boardViewCount = boardViewCount;
-        this.boardReviewCount = boardReviewCount;
+    public MemberMyPageDetailDto(long boardWriteCount, long boardReviewWriteCount){
+        this.boardWriteCount = boardWriteCount;
+        this.boardReviewWriteCount = boardReviewWriteCount;
     }
 }

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/dto/member/MemberMyPageDetailDto.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/dto/member/MemberMyPageDetailDto.java
@@ -1,0 +1,12 @@
+package ProjectDoge.StudentSoup.dto.member;
+
+public class MemberMyPageDetailDto {
+
+    private long boardViewCount;
+    private long boardReviewCount;
+
+    public MemberMyPageDetailDto(long boardViewCount, long boardReviewCount){
+        this.boardViewCount = boardViewCount;
+        this.boardReviewCount = boardReviewCount;
+    }
+}

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/dto/member/MemberMyPageDto.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/dto/member/MemberMyPageDto.java
@@ -3,7 +3,10 @@ package ProjectDoge.StudentSoup.dto.member;
 
 import ProjectDoge.StudentSoup.entity.file.ImageFile;
 import ProjectDoge.StudentSoup.entity.member.Member;
+import lombok.Data;
+import lombok.Getter;
 
+@Data
 public class MemberMyPageDto {
 
     private String nickName;

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/dto/member/MemberMyPageDto.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/dto/member/MemberMyPageDto.java
@@ -1,0 +1,21 @@
+package ProjectDoge.StudentSoup.dto.member;
+
+
+import ProjectDoge.StudentSoup.entity.member.Member;
+
+public class MemberMyPageDto {
+
+    private String nickName;
+    private String imageName;
+    private String schoolName;
+    private String departmentName;
+    private String registrationDate;
+
+    public MemberMyPageDto(Member member){
+        this.nickName = member.getNickname();
+        this.imageName = member.getImageFile().getFileName();
+        this.schoolName = member.getSchool().getSchoolName();
+        this.departmentName = member.getDepartment().getDepartmentName();
+        this.registrationDate = member.getRegistrationDate();
+    }
+}

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/dto/member/MemberMyPageDto.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/dto/member/MemberMyPageDto.java
@@ -1,6 +1,7 @@
 package ProjectDoge.StudentSoup.dto.member;
 
 
+import ProjectDoge.StudentSoup.entity.file.ImageFile;
 import ProjectDoge.StudentSoup.entity.member.Member;
 
 public class MemberMyPageDto {
@@ -13,9 +14,16 @@ public class MemberMyPageDto {
 
     public MemberMyPageDto(Member member){
         this.nickName = member.getNickname();
-        this.imageName = member.getImageFile().getFileName();
+        this.imageName = setImageFileName(member.getImageFile());
         this.schoolName = member.getSchool().getSchoolName();
         this.departmentName = member.getDepartment().getDepartmentName();
         this.registrationDate = member.getRegistrationDate();
+    }
+
+    private String setImageFileName(ImageFile imageFile){
+        if(imageFile != null){
+            return imageFile.getFileName();
+        }
+        return null;
     }
 }

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/dto/member/MemberMyPageRequestDto.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/dto/member/MemberMyPageRequestDto.java
@@ -1,0 +1,8 @@
+package ProjectDoge.StudentSoup.dto.member;
+
+import lombok.Data;
+
+@Data
+public class MemberMyPageRequestDto {
+    private Long memberId;
+}

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/dto/member/MemberMyPageRestaurantReviewDto.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/dto/member/MemberMyPageRestaurantReviewDto.java
@@ -1,9 +1,13 @@
 package ProjectDoge.StudentSoup.dto.member;
 
+import ProjectDoge.StudentSoup.entity.file.ImageFile;
+import ProjectDoge.StudentSoup.entity.restaurant.RestaurantReview;
 import com.querydsl.core.annotations.QueryProjection;
+import lombok.Data;
 
 import java.time.LocalDate;
 
+@Data
 public class MemberMyPageRestaurantReviewDto {
 
     private Long restaurantReviewId;
@@ -15,12 +19,18 @@ public class MemberMyPageRestaurantReviewDto {
     public MemberMyPageRestaurantReviewDto(){
     }
 
-    @QueryProjection
-    public MemberMyPageRestaurantReviewDto(Long restaurantReviewId, String imageName, int starLiked, String content, LocalDate writeDate){
-        this.restaurantReviewId = restaurantReviewId;
-        this.imageName = imageName;
-        this.starLiked = starLiked;
-        this.content = content;
-        this.writeDate = writeDate.toString();
+    public MemberMyPageRestaurantReviewDto(RestaurantReview restaurantReview){
+        this.restaurantReviewId = restaurantReview.getId();
+        this.imageName = setImageFileName(restaurantReview.getImageFileList().get(0));
+        this.starLiked = restaurantReview.getStarLiked();
+        this.content = restaurantReview.getContent();
+        this.writeDate = restaurantReview.getWriteDate().toString();
+    }
+
+    private String setImageFileName(ImageFile imageFile){
+        if(imageFile != null){
+            return imageFile.getFileName();
+        }
+        return null;
     }
 }

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/dto/member/MemberMyPageRestaurantReviewDto.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/dto/member/MemberMyPageRestaurantReviewDto.java
@@ -1,0 +1,26 @@
+package ProjectDoge.StudentSoup.dto.member;
+
+import com.querydsl.core.annotations.QueryProjection;
+
+import java.time.LocalDate;
+
+public class MemberMyPageRestaurantReviewDto {
+
+    private Long restaurantReviewId;
+    private String imageName;
+    private int starLiked;
+    private String content;
+    private String writeDate;
+
+    public MemberMyPageRestaurantReviewDto(){
+    }
+
+    @QueryProjection
+    public MemberMyPageRestaurantReviewDto(Long restaurantReviewId, String imageName, int starLiked, String content, LocalDate writeDate){
+        this.restaurantReviewId = restaurantReviewId;
+        this.imageName = imageName;
+        this.starLiked = starLiked;
+        this.content = content;
+        this.writeDate = writeDate.toString();
+    }
+}

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/repository/board/BoardRepositoryCustom.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/repository/board/BoardRepositoryCustom.java
@@ -1,6 +1,7 @@
 package ProjectDoge.StudentSoup.repository.board;
 
 import ProjectDoge.StudentSoup.dto.board.BoardMainDto;
+import ProjectDoge.StudentSoup.dto.member.MemberMyPageBoardDto;
 import ProjectDoge.StudentSoup.entity.board.Board;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -17,11 +18,11 @@ public interface BoardRepositoryCustom {
 
     Page<BoardMainDto> orderByCategory(Long schoolId, Long departmentId, String category, int sorted, Pageable pageable,String column,String value);
 
-
     Optional<BoardMainDto>  findAnnouncement();
 
     List<BoardMainDto> findLiveBestAndHotBoards(Long schoolId, LocalDateTime searchTime,LocalDateTime endDateTime);
 
-
     List<BoardMainDto> findBestTipBoards(Long schoolId);
+
+    Page<MemberMyPageBoardDto> callByMemberIdForMyPage(Long memberId, Pageable pageable);
 }

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/repository/board/BoardRepositoryCustom.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/repository/board/BoardRepositoryCustom.java
@@ -24,5 +24,5 @@ public interface BoardRepositoryCustom {
 
     List<BoardMainDto> findBestTipBoards(Long schoolId);
 
-    Page<MemberMyPageBoardDto> callByMemberIdForMyPage(Long memberId, Pageable pageable);
+    Page<MemberMyPageBoardDto> findByMemberIdForMyPage(Long memberId, Pageable pageable);
 }

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/repository/board/BoardRepositoryCustom.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/repository/board/BoardRepositoryCustom.java
@@ -25,4 +25,6 @@ public interface BoardRepositoryCustom {
     List<BoardMainDto> findBestTipBoards(Long schoolId);
 
     Page<MemberMyPageBoardDto> findByMemberIdForMyPage(Long memberId, Pageable pageable);
+
+    Long countByMemberId(Long memberId);
 }

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/repository/board/BoardRepositoryImpl.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/repository/board/BoardRepositoryImpl.java
@@ -219,13 +219,14 @@ public class BoardRepositoryImpl implements BoardRepositoryCustom {
     }
 
     @Override
-    public Page<MemberMyPageBoardDto> callByMemberIdForMyPage(Long memberId, Pageable pageable) {
+    public Page<MemberMyPageBoardDto> findByMemberIdForMyPage(Long memberId, Pageable pageable) {
 
         List<MemberMyPageBoardDto> content = queryFactory.select(new QMemberMyPageBoardDto(board.id, board.writeDate, board.likedCount, board.view))
                 .from(board)
                 .where(board.member.memberId.eq(memberId))
-                .offset(pageable.getPageNumber())
+                .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
+                .orderBy(board.writeDate.desc())
                 .fetch();
 
         JPAQuery<Long> count = queryFactory

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/repository/board/BoardRepositoryImpl.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/repository/board/BoardRepositoryImpl.java
@@ -237,6 +237,14 @@ public class BoardRepositoryImpl implements BoardRepositoryCustom {
         return PageableExecutionUtils.getPage(content, pageable, count::fetchOne);
     }
 
+    @Override
+    public Long countByMemberId(Long memberId) {
+        return queryFactory.select(board.count())
+                .from(board)
+                .where(board.member.memberId.eq(memberId))
+                .fetchOne();
+
+    }
 
 
 }

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/repository/board/BoardRepositoryImpl.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/repository/board/BoardRepositoryImpl.java
@@ -3,6 +3,8 @@ package ProjectDoge.StudentSoup.repository.board;
 import ProjectDoge.StudentSoup.dto.board.BoardMainDto;
 import ProjectDoge.StudentSoup.dto.board.BoardSortedCase;
 import ProjectDoge.StudentSoup.dto.board.QBoardMainDto;
+import ProjectDoge.StudentSoup.dto.member.MemberMyPageBoardDto;
+import ProjectDoge.StudentSoup.dto.member.QMemberMyPageBoardDto;
 import ProjectDoge.StudentSoup.entity.board.Board;
 import ProjectDoge.StudentSoup.entity.board.BoardCategory;
 import com.querydsl.core.types.Expression;
@@ -10,6 +12,7 @@ import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.JPQLQuery;
+import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -213,6 +216,24 @@ public class BoardRepositoryImpl implements BoardRepositoryCustom {
             return board.view.desc();
         }
         return board.updateDate.asc();
+    }
+
+    @Override
+    public Page<MemberMyPageBoardDto> callByMemberIdForMyPage(Long memberId, Pageable pageable) {
+
+        List<MemberMyPageBoardDto> content = queryFactory.select(new QMemberMyPageBoardDto(board.id, board.writeDate, board.likedCount, board.view))
+                .from(board)
+                .where(board.member.memberId.eq(memberId))
+                .offset(pageable.getPageNumber())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        JPAQuery<Long> count = queryFactory
+                .select(board.count())
+                .from(board)
+                .where(board.member.memberId.eq(memberId));
+
+        return PageableExecutionUtils.getPage(content, pageable, count::fetchOne);
     }
 
 

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/repository/boardreview/BoardReviewRepositoryCustom.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/repository/boardreview/BoardReviewRepositoryCustom.java
@@ -2,6 +2,7 @@ package ProjectDoge.StudentSoup.repository.boardreview;
 
 import ProjectDoge.StudentSoup.dto.member.MemberMyPageBoardReviewDto;
 import ProjectDoge.StudentSoup.entity.board.BoardReview;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 
@@ -9,5 +10,5 @@ import java.util.List;
 
 public interface BoardReviewRepositoryCustom {
 
-    List<MemberMyPageBoardReviewDto> callByMemberIdForMyPage(Long memberId, Pageable pageable);
+    Page<MemberMyPageBoardReviewDto> callByMemberIdForMyPage(Long memberId, Pageable pageable);
 }

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/repository/boardreview/BoardReviewRepositoryCustom.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/repository/boardreview/BoardReviewRepositoryCustom.java
@@ -7,4 +7,6 @@ import org.springframework.data.domain.Pageable;
 public interface BoardReviewRepositoryCustom {
 
     Page<MemberMyPageBoardReviewDto> findByMemberIdForMyPage(Long memberId, Pageable pageable);
+
+    Long countByMemberId(Long memberId);
 }

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/repository/boardreview/BoardReviewRepositoryCustom.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/repository/boardreview/BoardReviewRepositoryCustom.java
@@ -1,14 +1,10 @@
 package ProjectDoge.StudentSoup.repository.boardreview;
 
 import ProjectDoge.StudentSoup.dto.member.MemberMyPageBoardReviewDto;
-import ProjectDoge.StudentSoup.entity.board.BoardReview;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.stereotype.Repository;
-
-import java.util.List;
 
 public interface BoardReviewRepositoryCustom {
 
-    Page<MemberMyPageBoardReviewDto> callByMemberIdForMyPage(Long memberId, Pageable pageable);
+    Page<MemberMyPageBoardReviewDto> findByMemberIdForMyPage(Long memberId, Pageable pageable);
 }

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/repository/boardreview/BoardReviewRepositoryCustom.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/repository/boardreview/BoardReviewRepositoryCustom.java
@@ -1,7 +1,13 @@
 package ProjectDoge.StudentSoup.repository.boardreview;
 
+import ProjectDoge.StudentSoup.dto.member.MemberMyPageBoardReviewDto;
+import ProjectDoge.StudentSoup.entity.board.BoardReview;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 
-@Repository
-public interface BoardReviewRepositoryCustom{
+import java.util.List;
+
+public interface BoardReviewRepositoryCustom {
+
+    List<MemberMyPageBoardReviewDto> callByMemberIdForMyPage(Long memberId, Pageable pageable);
 }

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/repository/boardreview/BoardReviewRepositoryImpl.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/repository/boardreview/BoardReviewRepositoryImpl.java
@@ -18,14 +18,15 @@ import java.util.List;
 import static ProjectDoge.StudentSoup.entity.board.QBoardReview.boardReview;
 
 @RequiredArgsConstructor
-public class BoardReviewRepositoryImpl implements BoardReviewRepositoryCustom{
+public class BoardReviewRepositoryImpl implements BoardReviewRepositoryCustom {
 
     private final JPAQueryFactory queryFactory;
 
     @Override
     public Page<MemberMyPageBoardReviewDto> callByMemberIdForMyPage(Long memberId, Pageable pageable) {
 
-        List<MemberMyPageBoardReviewDto> content =  queryFactory.select(new QMemberMyPageBoardReviewDto(boardReview.content, boardReview.writeDate, boardReview.likedCount))
+        List<MemberMyPageBoardReviewDto> content = queryFactory.select(new QMemberMyPageBoardReviewDto(
+                        boardReview.board.id, boardReview.content, boardReview.writeDate, boardReview.likedCount))
                 .from(boardReview)
                 .where(boardReview.member.memberId.eq(memberId))
                 .offset(pageable.getPageNumber())

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/repository/boardreview/BoardReviewRepositoryImpl.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/repository/boardreview/BoardReviewRepositoryImpl.java
@@ -6,9 +6,12 @@ import ProjectDoge.StudentSoup.dto.member.QMemberMyPageBoardReviewDto;
 import ProjectDoge.StudentSoup.entity.board.BoardReview;
 import ProjectDoge.StudentSoup.entity.board.QBoardReview;
 import com.querydsl.core.Tuple;
+import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.support.PageableExecutionUtils;
 
 import java.util.List;
 
@@ -20,13 +23,19 @@ public class BoardReviewRepositoryImpl implements BoardReviewRepositoryCustom{
     private final JPAQueryFactory queryFactory;
 
     @Override
-    public List<MemberMyPageBoardReviewDto> callByMemberIdForMyPage(Long memberId, Pageable pageable) {
+    public Page<MemberMyPageBoardReviewDto> callByMemberIdForMyPage(Long memberId, Pageable pageable) {
 
-        return queryFactory.select(new QMemberMyPageBoardReviewDto(boardReview.content, boardReview.writeDate, boardReview.likedCount))
+        List<MemberMyPageBoardReviewDto> content =  queryFactory.select(new QMemberMyPageBoardReviewDto(boardReview.content, boardReview.writeDate, boardReview.likedCount))
                 .from(boardReview)
                 .where(boardReview.member.memberId.eq(memberId))
                 .offset(pageable.getPageNumber())
                 .limit(pageable.getPageSize())
                 .fetch();
+
+        JPAQuery<Long> count = queryFactory.select(boardReview.count())
+                .from(boardReview)
+                .where(boardReview.member.memberId.eq(memberId));
+
+        return PageableExecutionUtils.getPage(content, pageable, count::fetchOne);
     }
 }

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/repository/boardreview/BoardReviewRepositoryImpl.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/repository/boardreview/BoardReviewRepositoryImpl.java
@@ -40,4 +40,12 @@ public class BoardReviewRepositoryImpl implements BoardReviewRepositoryCustom {
 
         return PageableExecutionUtils.getPage(content, pageable, count::fetchOne);
     }
+
+    @Override
+    public Long countByMemberId(Long memberId) {
+        return queryFactory.select(boardReview.count())
+                .from(boardReview)
+                .where(boardReview.member.memberId.eq(memberId))
+                .fetchOne();
+    }
 }

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/repository/boardreview/BoardReviewRepositoryImpl.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/repository/boardreview/BoardReviewRepositoryImpl.java
@@ -1,5 +1,32 @@
 package ProjectDoge.StudentSoup.repository.boardreview;
 
 
+import ProjectDoge.StudentSoup.dto.member.MemberMyPageBoardReviewDto;
+import ProjectDoge.StudentSoup.dto.member.QMemberMyPageBoardReviewDto;
+import ProjectDoge.StudentSoup.entity.board.BoardReview;
+import ProjectDoge.StudentSoup.entity.board.QBoardReview;
+import com.querydsl.core.Tuple;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+
+import static ProjectDoge.StudentSoup.entity.board.QBoardReview.boardReview;
+
+@RequiredArgsConstructor
 public class BoardReviewRepositoryImpl implements BoardReviewRepositoryCustom{
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<MemberMyPageBoardReviewDto> callByMemberIdForMyPage(Long memberId, Pageable pageable) {
+
+        return queryFactory.select(new QMemberMyPageBoardReviewDto(boardReview.content, boardReview.writeDate, boardReview.likedCount))
+                .from(boardReview)
+                .where(boardReview.member.memberId.eq(memberId))
+                .offset(pageable.getPageNumber())
+                .limit(pageable.getPageSize())
+                .fetch();
+    }
 }

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/repository/boardreview/BoardReviewRepositoryImpl.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/repository/boardreview/BoardReviewRepositoryImpl.java
@@ -23,14 +23,15 @@ public class BoardReviewRepositoryImpl implements BoardReviewRepositoryCustom {
     private final JPAQueryFactory queryFactory;
 
     @Override
-    public Page<MemberMyPageBoardReviewDto> callByMemberIdForMyPage(Long memberId, Pageable pageable) {
+    public Page<MemberMyPageBoardReviewDto> findByMemberIdForMyPage(Long memberId, Pageable pageable) {
 
         List<MemberMyPageBoardReviewDto> content = queryFactory.select(new QMemberMyPageBoardReviewDto(
                         boardReview.board.id, boardReview.content, boardReview.writeDate, boardReview.likedCount))
                 .from(boardReview)
                 .where(boardReview.member.memberId.eq(memberId))
-                .offset(pageable.getPageNumber())
+                .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
+                .orderBy(boardReview.writeDate.desc())
                 .fetch();
 
         JPAQuery<Long> count = queryFactory.select(boardReview.count())

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/repository/restaurantreview/RestaurantReviewRepositoryCustom.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/repository/restaurantreview/RestaurantReviewRepositoryCustom.java
@@ -1,7 +1,9 @@
 package ProjectDoge.StudentSoup.repository.restaurantreview;
 
+import ProjectDoge.StudentSoup.dto.member.MemberMyPageRestaurantReviewDto;
 import ProjectDoge.StudentSoup.entity.restaurant.RestaurantReview;
 import com.querydsl.jpa.impl.JPAQuery;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 import java.util.List;
@@ -15,4 +17,6 @@ public interface RestaurantReviewRepositoryCustom {
     List<RestaurantReview> findByRestaurantIdSorted(Long restaurantId, String sorted, Pageable pageable);
 
     JPAQuery<Long> pagingCountByRestaurantId(Long restaurantId);
+
+    Page<MemberMyPageRestaurantReviewDto> findByMemberIdForMyPage(Long memberId, String cond, Pageable pageable);
 }

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/repository/restaurantreview/RestaurantReviewRepositoryCustom.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/repository/restaurantreview/RestaurantReviewRepositoryCustom.java
@@ -18,5 +18,5 @@ public interface RestaurantReviewRepositoryCustom {
 
     JPAQuery<Long> pagingCountByRestaurantId(Long restaurantId);
 
-    Page<MemberMyPageRestaurantReviewDto> findByMemberIdForMyPage(Long memberId, String cond, Pageable pageable);
+    Page<RestaurantReview> findByMemberIdForMyPage(Long memberId, String cond, Pageable pageable);
 }

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/repository/restaurantreview/RestaurantReviewRepositoryImpl.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/repository/restaurantreview/RestaurantReviewRepositoryImpl.java
@@ -83,11 +83,9 @@ public class RestaurantReviewRepositoryImpl implements RestaurantReviewRepositor
     }
 
     @Override
-    public Page<MemberMyPageRestaurantReviewDto> findByMemberIdForMyPage(Long memberId, String cond, Pageable pageable) {
+    public Page<RestaurantReview> findByMemberIdForMyPage(Long memberId, String cond, Pageable pageable) {
 
-        List<MemberMyPageRestaurantReviewDto> content = queryFactory.select(new QMemberMyPageRestaurantReviewDto(
-                restaurantReview.id, restaurantReview.imageFileList.get(0).fileName, restaurantReview.starLiked,
-                restaurantReview.content, restaurantReview.writeDate))
+        List<RestaurantReview> content = queryFactory.select(restaurantReview)
                 .from(restaurantReview)
                 .where(restaurantReview.member.memberId.eq(memberId), checkMyPageSortCond(cond))
                 .offset(pageable.getOffset())
@@ -103,7 +101,9 @@ public class RestaurantReviewRepositoryImpl implements RestaurantReviewRepositor
     }
 
     private BooleanExpression checkMyPageSortCond(String cond){
-        if(cond.equals("today"))
+        if(cond == null)
+            return null;
+        else if(cond.equals("today"))
             return restaurantReview.writeDate.eq(LocalDate.now());
         else if(cond.equals("month"))
             return restaurantReview.writeDate.between(LocalDate.now().minusMonths(1), LocalDate.now());

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/service/member/MemberMyPageCallService.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/service/member/MemberMyPageCallService.java
@@ -2,9 +2,11 @@ package ProjectDoge.StudentSoup.service.member;
 
 import ProjectDoge.StudentSoup.dto.member.*;
 import ProjectDoge.StudentSoup.entity.member.Member;
+import ProjectDoge.StudentSoup.entity.restaurant.RestaurantReview;
 import ProjectDoge.StudentSoup.exception.member.MemberIdNotSentException;
 import ProjectDoge.StudentSoup.repository.board.BoardRepository;
 import ProjectDoge.StudentSoup.repository.boardreview.BoardReviewRepository;
+import ProjectDoge.StudentSoup.repository.member.MemberRepository;
 import ProjectDoge.StudentSoup.repository.restaurantreview.RestaurantReviewRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -20,12 +22,11 @@ public class MemberMyPageCallService {
     private final BoardRepository boardRepository;
     private final BoardReviewRepository boardReviewRepository;
     private final RestaurantReviewRepository restaurantReviewRepository;
-    private final MemberFindService memberFindService;
-
+    private final MemberRepository memberRepository;
     @Transactional(readOnly = true, rollbackFor = Exception.class)
     public MemberMyPageDto callMyPageMain(Long memberId){
         isNotNullMemberId(memberId);
-        Member member = memberFindService.findOne(memberId);
+        Member member = memberRepository.fullFindById(memberId);
         return new MemberMyPageDto(member);
     }
 
@@ -54,7 +55,8 @@ public class MemberMyPageCallService {
     @Transactional(readOnly = true, rollbackFor = Exception.class)
     public Page<MemberMyPageRestaurantReviewDto> callMyRestaurantReview(Long memberId, String cond, Pageable pageable){
         isNotNullMemberId(memberId);
-        return restaurantReviewRepository.findByMemberIdForMyPage(memberId, cond, pageable);
+        Page<RestaurantReview> pagingRestaurantReview = restaurantReviewRepository.findByMemberIdForMyPage(memberId, cond, pageable);
+        return pagingRestaurantReview.map(MemberMyPageRestaurantReviewDto::new);
     }
 
     private void isNotNullMemberId(Long memberId) {

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/service/member/MemberMyPageCallService.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/service/member/MemberMyPageCallService.java
@@ -2,9 +2,11 @@ package ProjectDoge.StudentSoup.service.member;
 
 import ProjectDoge.StudentSoup.dto.member.MemberMyPageBoardDto;
 import ProjectDoge.StudentSoup.dto.member.MemberMyPageBoardReviewDto;
+import ProjectDoge.StudentSoup.dto.member.MemberMyPageRestaurantReviewDto;
 import ProjectDoge.StudentSoup.exception.member.MemberIdNotSentException;
 import ProjectDoge.StudentSoup.repository.board.BoardRepository;
 import ProjectDoge.StudentSoup.repository.boardreview.BoardReviewRepository;
+import ProjectDoge.StudentSoup.repository.restaurantreview.RestaurantReviewRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
@@ -18,18 +20,25 @@ import org.springframework.transaction.annotation.Transactional;
 public class MemberMyPageCallService {
     private final BoardRepository boardRepository;
     private final BoardReviewRepository boardReviewRepository;
+    private final RestaurantReviewRepository restaurantReviewRepository;
 
 
     @Transactional(readOnly = true, rollbackFor = Exception.class)
     public Page<MemberMyPageBoardReviewDto> callMyPageBoardReview(Long memberId, Pageable pageable){
         isNotNullMemberId(memberId);
-        return boardReviewRepository.callByMemberIdForMyPage(memberId, pageable);
+        return boardReviewRepository.findByMemberIdForMyPage(memberId, pageable);
     }
 
     @Transactional(readOnly = true, rollbackFor = Exception.class)
     public Page<MemberMyPageBoardDto> callMyPageBoard(Long memberId, Pageable pageable){
         isNotNullMemberId(memberId);
-        return boardRepository.callByMemberIdForMyPage(memberId, pageable);
+        return boardRepository.findByMemberIdForMyPage(memberId, pageable);
+    }
+
+    @Transactional(readOnly = true, rollbackFor = Exception.class)
+    public Page<MemberMyPageRestaurantReviewDto> callMyRestaurantReview(Long memberId, String cond, Pageable pageable){
+        isNotNullMemberId(memberId);
+        return restaurantReviewRepository.findByMemberIdForMyPage(memberId, cond, pageable);
     }
 
     private void isNotNullMemberId(Long memberId) {

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/service/member/MemberMyPageCallService.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/service/member/MemberMyPageCallService.java
@@ -1,0 +1,33 @@
+package ProjectDoge.StudentSoup.service.member;
+
+import ProjectDoge.StudentSoup.dto.member.MemberMyPageBoardReviewDto;
+import ProjectDoge.StudentSoup.exception.member.MemberIdNotSentException;
+import ProjectDoge.StudentSoup.repository.board.BoardRepository;
+import ProjectDoge.StudentSoup.repository.boardreview.BoardReviewRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class MemberMyPageCallService {
+    private final BoardRepository boardRepository;
+    private final BoardReviewRepository boardReviewRepository;
+
+
+    @Transactional(readOnly = true, rollbackFor = Exception.class)
+    public Page<MemberMyPageBoardReviewDto> callMyPageBoardReview(Long memberId, Pageable pageable){
+        isNotNullMemberId(memberId);
+        return boardReviewRepository.callByMemberIdForMyPage(memberId, pageable);
+    }
+
+    private void isNotNullMemberId(Long memberId) {
+        if(memberId == null){
+            throw new MemberIdNotSentException("회원의 기본키가 전달되지 않았습니다.");
+        }
+    }
+}

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/service/member/MemberMyPageCallService.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/service/member/MemberMyPageCallService.java
@@ -1,8 +1,7 @@
 package ProjectDoge.StudentSoup.service.member;
 
-import ProjectDoge.StudentSoup.dto.member.MemberMyPageBoardDto;
-import ProjectDoge.StudentSoup.dto.member.MemberMyPageBoardReviewDto;
-import ProjectDoge.StudentSoup.dto.member.MemberMyPageRestaurantReviewDto;
+import ProjectDoge.StudentSoup.dto.member.*;
+import ProjectDoge.StudentSoup.entity.member.Member;
 import ProjectDoge.StudentSoup.exception.member.MemberIdNotSentException;
 import ProjectDoge.StudentSoup.repository.board.BoardRepository;
 import ProjectDoge.StudentSoup.repository.boardreview.BoardReviewRepository;
@@ -21,6 +20,23 @@ public class MemberMyPageCallService {
     private final BoardRepository boardRepository;
     private final BoardReviewRepository boardReviewRepository;
     private final RestaurantReviewRepository restaurantReviewRepository;
+    private final MemberFindService memberFindService;
+
+    @Transactional(readOnly = true, rollbackFor = Exception.class)
+    public MemberMyPageDto callMyPageMain(Long memberId){
+        isNotNullMemberId(memberId);
+        Member member = memberFindService.findOne(memberId);
+        return new MemberMyPageDto(member);
+    }
+
+    @Transactional(readOnly = true, rollbackFor = Exception.class)
+    public MemberMyPageDetailDto callMyPageDetail(Long memberId){
+        isNotNullMemberId(memberId);
+        Long boardCount = boardRepository.countByMemberId(memberId);
+        Long boardReviewCount = boardReviewRepository.countByMemberId(memberId);
+
+        return new MemberMyPageDetailDto(boardCount, boardReviewCount);
+    }
 
 
     @Transactional(readOnly = true, rollbackFor = Exception.class)

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/service/member/MemberMyPageCallService.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/service/member/MemberMyPageCallService.java
@@ -1,5 +1,6 @@
 package ProjectDoge.StudentSoup.service.member;
 
+import ProjectDoge.StudentSoup.dto.member.MemberMyPageBoardDto;
 import ProjectDoge.StudentSoup.dto.member.MemberMyPageBoardReviewDto;
 import ProjectDoge.StudentSoup.exception.member.MemberIdNotSentException;
 import ProjectDoge.StudentSoup.repository.board.BoardRepository;
@@ -23,6 +24,12 @@ public class MemberMyPageCallService {
     public Page<MemberMyPageBoardReviewDto> callMyPageBoardReview(Long memberId, Pageable pageable){
         isNotNullMemberId(memberId);
         return boardReviewRepository.callByMemberIdForMyPage(memberId, pageable);
+    }
+
+    @Transactional(readOnly = true, rollbackFor = Exception.class)
+    public Page<MemberMyPageBoardDto> callMyPageBoard(Long memberId, Pageable pageable){
+        isNotNullMemberId(memberId);
+        return boardRepository.callByMemberIdForMyPage(memberId, pageable);
     }
 
     private void isNotNullMemberId(Long memberId) {


### PR DESCRIPTION
## 1. Changes
1. 마이 페이지를 호출하였을 때 필요한 응답 객체를 추가하였습니다.
2. 마이 페이지의 회원의 게시글과 댓글을 간단히 보여지는 호출 api와 그 응답 객체를 추가하였습니다.
3. 마이 페이지에서 작성 게시글과 댓글 수를 볼 수 있는 호출 api와 그 응답 객체를 추가하였습니다.
4. 마이 페이지에서 게시글, 댓글, 음식점 리뷰의 페이징을 적용하였고, 그에 필요한 응답 객체를 추가하였습니다.

## 2. Screenshot

-

## 3. Issues

1. 마이 페이지 관련 호출 시 응답 DTO의 미디어 타입이 일치하지 않는 문제가 있었습니다.
`Could not find acceptable representation` 다음과 같은 오류가 발생을 했으며, `Header`에 있는 `MediaType`을 확인했으나, 문제가 있어보이진 않았습니다. 자잘한 실수로 인해서 발생한 문제인데, 기본적으로 스프링은 `Jackson`을 이용하여 **Json으로 변환**을 하는데 이 과정에서 프로퍼티가 필요합니다. 따라서 `Getter`와 `Setter`를 **Dto에 추가**해줬어야 했는데, 추가하지 않은 상태에서 `Jackson`을 이용하여 변환하는데 오류가 생겨 문제가 있는 것이였습니다. 각 응답 `DTO`에 `@Data` **애노테이션을 추가**해줌으로써 해결되었습니다.

2. `Paging` 처리를 한 응답 객체를 받기 위해 응답 객체에 대해 `@QueryProjection` 을 사용하여 QueryDsl에서 바로 생성할 수 있도록 하였습니다. 그러나 `ImageFile` 같은 경우는 안 가지고 있는 경우`(=null)`가 있어, 생성을 하는 과정에서 문제가 발생을 했습니다.
따라서 `null` 값이 **존재할 수 있는 필드 및 DTO** 에 한해서는 `Entity`를 `반환하는 Page`를 받고, `page.map(dto::new)`를 통해서 생성 시 발생할 수 있는 `null` 처리를 해주어 해결해 줄 수 있었습니다.

## 4. To Reviewer

-

## 5. Plans
- [x] - 마이페이지 api 호출 테스트
