### PR TITLE
mjw/s3BucketTest

### DIFF
--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/controller/image/ImageResponseController.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/controller/image/ImageResponseController.java
@@ -1,9 +1,8 @@
 package ProjectDoge.StudentSoup.controller.image;
 
-import ProjectDoge.StudentSoup.service.file.LocalFileService;
+import ProjectDoge.StudentSoup.service.file.FileService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.core.io.Resource;
 import org.springframework.core.io.UrlResource;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -17,11 +16,14 @@ import java.net.MalformedURLException;
 
 public class ImageResponseController {
 
-    private final LocalFileService localFileService;
+    private final FileService fileService;
 
     @GetMapping("/image/{fileName}")
-    public Resource responseImage(@PathVariable String fileName) throws MalformedURLException {
-        log.info("이미지 호출이 시작되었습니다. 해당 이미지의 이름 : [{}], 저장 위치 : [{}]", fileName, localFileService.getFullPath(fileName));
-        return new UrlResource("file:" + localFileService.getFullPath(fileName));
+    public Object responseImage(@PathVariable String fileName) throws MalformedURLException {
+        log.info("이미지 호출이 시작되었습니다. 해당 이미지의 이름 : [{}], 저장 위치 : [{}]", fileName, fileService.getFullPath(fileName));
+        String filePath = fileService.getFullPath(fileName);
+        if(filePath.startsWith("https://"))
+            return (String)filePath;
+        return new UrlResource("file:" + fileService.getFullPath(fileName));
     }
 }

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/service/file/FileService.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/service/file/FileService.java
@@ -16,4 +16,5 @@ public interface FileService {
 
     String createStoreFileName(String originalFileName);
 
+    String getFullPath(String fileName);
 }

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/service/file/S3FileService.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/service/file/S3FileService.java
@@ -139,8 +139,8 @@ public class S3FileService implements FileService {
         return !ext.equals("jpeg") && !ext.equals("jpg") && !ext.equals("bmp") && !ext.equals("gif") && !ext.equals("png") && !ext.equals("svg");
     }
 
-    private String getFullPath(String fileName){
-        return bucket + fileName;
+    public String getFullPath(String fileName){
+        return amazonS3Client.getUrl(bucket, fileName).toString();
     }
 
     private void removeFile(File createFile) {


### PR DESCRIPTION
## 1. Changes
- S3 버킷의 이미지 테스트를 진행하였습니다.
- S3 버킷에 있는 이미지 파일 링크를 정상적으로 불러올 수 있도록 서비스 로직을 변경하였습니다.

## 2. Screenshot

-

## 3. Issues

1.
먼저 많은 고민을 한 부분이 `Primary`를 이용하여 **상황에 따른 다른 구현체를 사용**하고 있는데, 현재 `Local`과 `S3`를 이용하는 상태에서 두 개의 경로가 다르기 때문에 **둘을 철저하게 분리를 해줄 필요**가 있었습니다.
제일 확실한 방법은 인터페이스에 주입된 구현체가 무엇인지를 확인하고 이 인터페이스가 구현된 클래스가 A 클래스라면 A 클래스의 반환 타입을 선택하고 B클래스라면 B 클래스의 반환타입을 선택하여 반환을 해주는 방법이 가장 확실한 방법이였습니다. 
먼저 떠오른 것은 `instanceOf` 방식이였으나, 해당 방식은 **상속관계를 확인하는 것**이기 때문에 별로 도움이 될 순 없었습니다.
두 번째로는 `AnnotationApplicationContext` 에서 해당 클래스를 구현한 빈들을 참조하여 우선 순위에 따라 구현된 빈이 다르기 때문에 **인터페이스 -> Primary 구현체 -> 다음 구현체 순**으로 등록이 되기 때문에 `String[]` 으로 반환되는 배열에서 1번 인덱스의 값이 A 클래스라면, B 클래스라면 으로 진행하는 방식이 있었습니다. 해당 방식이 가장 직관적이라고는 생각이 됩니다.

그러나 가장 간단한 방식으로 **S3 일 때의 반환되는 첫 글자와 Local에서의 반환되는 첫글자가 Url 형식과, 저장소 형식으로 문자열의 시작 부분이 확실히 다를 수 밖에 없는 부분**이기 때문에 `문자열 첫번째로 분리하는 방식`을 채택하였습니다.
```java
if(fileService.getFullPath(fileName).startWith("https://"))
    return (String)fileService.getFullPath(fileName);

return new UrlResource("file:" + fileService.getFullPath(fileName)); 
```
다음과 같은 코드를 사용하여 간단하게 구현체의 코드를 분리할 수 있었으나, 나중에 확장성을 생각했을 때는 확실히 문제가 있는 코드라는 부분을 알 수 있었습니다. 따라서 더 좋은 방식은 applicaiton.yml에 "local"과 "build"를 또 따로 나눠서 나중에는 "build" 일 경우에는 해당 코드를 실행하는 방식으로 하는 것도 좋은 방법이라고 생각이 듭니다. 해당 코드는 인프런에 질문을 올려 차후에 좋은 답변이 도착한다면 추가로 올리도록 하겠습니다.
2. 

## 4. To Reviewer

-

## 5. Plans
