### PR TITLE
mjw/adminInterceptor

### DIFF
--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/config/AdminConfig.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/config/AdminConfig.java
@@ -1,0 +1,18 @@
+package ProjectDoge.StudentSoup.config;
+
+import ProjectDoge.StudentSoup.interceptor.AdminInterceptor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class AdminConfig implements WebMvcConfigurer {
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(new AdminInterceptor())
+                .order(1)
+                .addPathPatterns("/admin", "/admin/**")
+                .excludePathPatterns("/css/**", "/*.ico", "/error", "/js/**");
+    }
+}

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/controller/member/LoginController.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/controller/member/LoginController.java
@@ -4,8 +4,10 @@ import ProjectDoge.StudentSoup.dto.member.MemberDto;
 import ProjectDoge.StudentSoup.dto.member.MemberLoginRequestDto;
 import ProjectDoge.StudentSoup.interceptor.SessionConst;
 import ProjectDoge.StudentSoup.service.member.MemberLoginService;
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -28,6 +30,25 @@ public class LoginController {
         MemberDto loginDto = memberLoginService.login(dto.getId(), dto.getPwd());
         HttpSession session = request.getSession();
         session.setAttribute(SessionConst.LOGIN_MEMBER, loginDto.getMemberClassification());
+        session.setMaxInactiveInterval(1800); // 세션의 생명주기 30분으로 고정
         return loginDto;
+    }
+
+    @PostMapping("/logout")
+    public ResponseEntity<Result<String>> logout(HttpServletRequest request){
+        HttpSession session = request.getSession(false);
+        if(session != null) {
+            session.invalidate();
+        }
+        return ResponseEntity.ok(new Result<String>("ok"));
+    }
+
+    @Getter
+    static class Result<T> {
+        private final T data;
+
+        public Result(T data){
+            this.data = data;
+        }
     }
 }

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/controller/member/LoginController.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/controller/member/LoginController.java
@@ -2,6 +2,7 @@ package ProjectDoge.StudentSoup.controller.member;
 
 import ProjectDoge.StudentSoup.dto.member.MemberDto;
 import ProjectDoge.StudentSoup.dto.member.MemberLoginRequestDto;
+import ProjectDoge.StudentSoup.interceptor.SessionConst;
 import ProjectDoge.StudentSoup.service.member.MemberLoginService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -10,7 +11,8 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.util.Map;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpSession;
 
 @Slf4j
 @RestController
@@ -21,7 +23,11 @@ public class LoginController {
     private final MemberLoginService memberLoginService;
 
     @PostMapping("/login")
-    public MemberDto login(@RequestBody MemberLoginRequestDto dto){
-        return memberLoginService.login(dto.getId(), dto.getPwd());
+    public MemberDto login(@RequestBody MemberLoginRequestDto dto, HttpServletRequest request){
+
+        MemberDto loginDto = memberLoginService.login(dto.getId(), dto.getPwd());
+        HttpSession session = request.getSession();
+        session.setAttribute(SessionConst.LOGIN_MEMBER, loginDto.getMemberClassification());
+        return loginDto;
     }
 }

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/dto/member/MemberDto.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/dto/member/MemberDto.java
@@ -19,6 +19,7 @@ public class MemberDto {
     private String nickname;
     private String email;
     private String registrationDate;
+    private String memberClassification;
 
 
     // 생성 메소드
@@ -37,6 +38,7 @@ public class MemberDto {
         } else{
             this.fileName = member.getImageFile().getFileName();
         }
+        this.memberClassification = member.getMemberClassification().toString();
         return this;
     }
 }

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/exception/admin/MemberClassificationNotAdminException.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/exception/admin/MemberClassificationNotAdminException.java
@@ -1,0 +1,23 @@
+package ProjectDoge.StudentSoup.exception.admin;
+
+public class MemberClassificationNotAdminException extends RuntimeException {
+    public MemberClassificationNotAdminException() {
+        super();
+    }
+
+    public MemberClassificationNotAdminException(String message) {
+        super(message);
+    }
+
+    public MemberClassificationNotAdminException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public MemberClassificationNotAdminException(Throwable cause) {
+        super(cause);
+    }
+
+    protected MemberClassificationNotAdminException(String message, Throwable cause, boolean enableSuppression, boolean writableStackTrace) {
+        super(message, cause, enableSuppression, writableStackTrace);
+    }
+}

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/exhandler/advice/AdminAdvice.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/exhandler/advice/AdminAdvice.java
@@ -1,0 +1,22 @@
+package ProjectDoge.StudentSoup.exhandler.advice;
+
+import ProjectDoge.StudentSoup.exception.admin.MemberClassificationNotAdminException;
+import ProjectDoge.StudentSoup.exception.board.BoardNotFoundException;
+import ProjectDoge.StudentSoup.exhandler.ErrorResult;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@Slf4j
+@ControllerAdvice
+public class AdminAdvice {
+
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @ExceptionHandler(MemberClassificationNotAdminException.class)
+    public ErrorResult MemberClassificationNotAdminHandler(MemberClassificationNotAdminException e){
+        log.error("[exceptionHandle] ex", e);
+        return new ErrorResult("MemberClassificationNotAdmin", e.getMessage());
+    }
+}

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/init/TestDataInit.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/init/TestDataInit.java
@@ -26,6 +26,7 @@ import ProjectDoge.StudentSoup.service.BoardReview.BoardReviewRegisterService;
 import ProjectDoge.StudentSoup.service.board.BoardResisterService;
 import ProjectDoge.StudentSoup.service.department.DepartmentRegisterService;
 import ProjectDoge.StudentSoup.service.member.MemberRegisterService;
+import ProjectDoge.StudentSoup.service.member.MemberUpdateService;
 import ProjectDoge.StudentSoup.service.restaurant.RestaurantFindService;
 import ProjectDoge.StudentSoup.service.restaurant.RestaurantRegisterService;
 import ProjectDoge.StudentSoup.service.restaurantmenu.RestaurantMenuRegisterService;
@@ -33,6 +34,7 @@ import ProjectDoge.StudentSoup.service.restaurantreview.RestaurantReviewRegister
 import ProjectDoge.StudentSoup.service.school.SchoolFindService;
 import ProjectDoge.StudentSoup.service.school.SchoolRegisterService;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.context.event.ApplicationReadyEvent;
 import org.springframework.context.annotation.Profile;
 import org.springframework.context.event.EventListener;
@@ -43,11 +45,12 @@ import java.util.Collections;
 import java.util.List;
 
 @Component
+@Slf4j
 @Profile("local")
 @RequiredArgsConstructor
 public class TestDataInit {
     private final MemberRegisterService memberRegisterService;
-    private final SchoolRepository schoolRepository;
+    private final MemberUpdateService memberUpdateService;
     private final SchoolRegisterService schoolRegisterService;
     private final SchoolFindService schoolFindService;
     private final DepartmentRepository departmentRepository;
@@ -139,6 +142,8 @@ public class TestDataInit {
                 GenderType.WOMAN, schoolId2, departments2.get(1).getId());
         MemberFormBDto dto6 = createMemberFormDto("dummyTest6", "test123!", "더미테스트6", "dummytest6@naver.com",
                 GenderType.WOMAN, schoolId2, departments2.get(1).getId());
+        MemberFormBDto dto7 = createMemberFormDto("admin", "admin123!", "운영자", "admin@naver.com",
+                GenderType.MAN, schoolId2, departments2.get(1).getId());
 
         memberRegisterService.join(dto1);
         memberRegisterService.join(dto2);
@@ -146,6 +151,9 @@ public class TestDataInit {
         memberRegisterService.join(dto4);
         memberRegisterService.join(dto5);
         memberRegisterService.join(dto6);
+        memberRegisterService.join(dto7);
+
+        memberRepository.findById("admin").ifPresent(memberUpdateService::updateMemberClassification);
     }
 
     private void initRestaurant(){

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/interceptor/AdminInterceptor.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/interceptor/AdminInterceptor.java
@@ -1,0 +1,30 @@
+package ProjectDoge.StudentSoup.interceptor;
+
+import ProjectDoge.StudentSoup.entity.member.MemberClassification;
+import ProjectDoge.StudentSoup.exception.admin.MemberClassificationNotAdminException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpSession;
+
+@Slf4j
+public class AdminInterceptor implements HandlerInterceptor {
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
+
+        String requestURI = request.getRequestURI();
+
+        log.info("인증 체크 인터셉터 실행 {}", requestURI);
+        HttpSession session = request.getSession(false);
+
+        if (session == null || !session.getAttribute(SessionConst.LOGIN_MEMBER).equals(MemberClassification.ADMIN.toString())){
+            log.info("미인증 사용자 요청");
+            // 로그인으로 redirect
+            throw new MemberClassificationNotAdminException("로그인 한 회원은 운영자가 아닙니다.");
+        }
+        return true;
+    }
+}

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/interceptor/SessionConst.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/interceptor/SessionConst.java
@@ -1,0 +1,5 @@
+package ProjectDoge.StudentSoup.interceptor;
+
+public class SessionConst {
+    public static final String LOGIN_MEMBER = "loginMember";
+}

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/service/member/MemberUpdateService.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/service/member/MemberUpdateService.java
@@ -2,15 +2,16 @@ package ProjectDoge.StudentSoup.service.member;
 
 import ProjectDoge.StudentSoup.dto.member.MemberUpdateDto;
 import ProjectDoge.StudentSoup.entity.member.Member;
+import ProjectDoge.StudentSoup.entity.member.MemberClassification;
 import ProjectDoge.StudentSoup.entity.school.Department;
 import ProjectDoge.StudentSoup.entity.school.School;
+import ProjectDoge.StudentSoup.repository.member.MemberRepository;
 import ProjectDoge.StudentSoup.service.department.DepartmentFindService;
 import ProjectDoge.StudentSoup.service.school.SchoolFindService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
-
-import javax.transaction.Transactional;
+import org.springframework.transaction.annotation.Transactional;
 
 @Slf4j
 @Service
@@ -21,6 +22,8 @@ public class MemberUpdateService {
     private final MemberValidationService memberValidationService;
     private final SchoolFindService schoolFindService;
     private final DepartmentFindService departmentFindService;
+
+    private final MemberRepository memberRepository;
 
 
     @Transactional
@@ -57,5 +60,11 @@ public class MemberUpdateService {
         member.setPwd(dto.getPwd());
         member.setEmail(dto.getEmail());
         member.setNickname(dto.getNickname());
+    }
+
+    @Transactional(rollbackFor = Exception.class)
+    public void updateMemberClassification(Member member){
+        member.setMemberClassification(MemberClassification.ADMIN);
+        memberRepository.save(member);
     }
 }


### PR DESCRIPTION
## 1. Changes
- 운영자 페이지 접근 제한 로직을 추가하였습니다.
- 회원의 등급을 수정할 수 있는 서비스 로직을 추가했습니다.

## 2. Screenshot

-

## 3. Issues

1. 회원 등급을 수정하면서 dirtyChecking이 자동적으로 될 것이라고 생각하였으나, 체크를 하더라도 save를 다시 해줄 필요가 있었습니다.
예를 들어서 회원의 엔티티를 받고 등급을 업데이트를 하는 과정에서 다음과 같이 코드를 작성했습니다.
```java
@Transactional(rollbackFor = Exception.class)
    public void updateMemberClassification(Member member){
        member.setMemberClassification(MemberClassification.ADMIN);
    }
```
이 때, 회원이 업데이트를 안 되는 것을 확인할 수 있었는데 회원 등록 이후에 detach가 되었기 때문에 확인을 할 수 없는 것이었다.
따라서, 다음과 같이 코드를 수정해주었다.
```java
@Transactional(rollbackFor = Exception.class)
    public void updateMemberClassification(Member member){
        member.setMemberClassification(MemberClassification.ADMIN);
        memberRepository.save(member);
    }
```
이후, 회원의 등급이 업데이트 되는 것을 확인할 수 있었다.

2. 

## 4. To Reviewer

-

## 5. Plans
- [x] 로그아웃 시 메모리에 세션 비워주는 기능 추가