### PR TITLE
mjw/boardTest

### DIFF
--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/commonmodule/ConstField.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/commonmodule/ConstField.java
@@ -1,7 +1,13 @@
 package ProjectDoge.StudentSoup.commonmodule;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
 public class ConstField {
 
     public static final boolean LIKED = true;
     public static final boolean NOT_LIKED = false;
+
+    public static final LocalDateTime startTime = LocalDate.now().atTime(0, 0, 0);
+    public static final LocalDateTime endTime = LocalDate.now().atTime(23, 59, 59);
 }

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/commonmodule/ConstField.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/commonmodule/ConstField.java
@@ -1,0 +1,7 @@
+package ProjectDoge.StudentSoup.commonmodule;
+
+public class ConstField {
+
+    public static final boolean LIKED = true;
+    public static final boolean NOT_LIKED = false;
+}

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/controller/board/BoardCallController.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/controller/board/BoardCallController.java
@@ -5,19 +5,17 @@ import ProjectDoge.StudentSoup.dto.board.BoardDto;
 import ProjectDoge.StudentSoup.dto.board.BoardMainDto;
 import ProjectDoge.StudentSoup.dto.board.BoardSearchDto;
 import ProjectDoge.StudentSoup.dto.department.DepartmentCallDto;
-import ProjectDoge.StudentSoup.dto.department.DepartmentFormDto;
 import ProjectDoge.StudentSoup.exception.page.PagingLimitEqualsZeroException;
 import ProjectDoge.StudentSoup.service.board.BoardCallService;
 import ProjectDoge.StudentSoup.service.department.DepartmentFindService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
-import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 
 @Slf4j
@@ -30,16 +28,16 @@ public class BoardCallController {
 
     /**
      * @param category
-     * @param sorted  0 normal(업데이트 순), 1(좋아요 5개 이상), 2(좋아요 순)
+     * @param sorted  0 normal(작성 순), 1(좋아요 5개 이상), 2(좋아요 순)
      * @param boardCallDto schoolId memberId departmentId
      * @return
      */
     @PostMapping ("/boards")
-    public Map<String, Object> callBoards(@RequestParam String category,
-                                          @RequestParam int sorted,
-                                          BoardSearchDto boardSearchDto,
-                                          @RequestBody BoardCallDto boardCallDto,
-                                          @PageableDefault(size = 12) Pageable pageable){
+    public ConcurrentHashMap<String, Object> callBoards(@RequestParam(defaultValue = "ALL") String category,
+                                                        @RequestParam(defaultValue = "0") int sorted,
+                                                        BoardSearchDto boardSearchDto,
+                                                        @RequestBody BoardCallDto boardCallDto,
+                                                        @PageableDefault(size = 12) Pageable pageable){
         log.info("category [{}], sorted [{}] schoolId[{}] departmentId [{}] memberId [{}] offset[{}] size [{}] column [{}] value [{}]",
                 category,
                 sorted,

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/dto/board/BoardMainDto.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/dto/board/BoardMainDto.java
@@ -10,16 +10,13 @@ import lombok.Setter;
 @Setter
 public class BoardMainDto {
     private Long boardId;
-
     private BoardCategory boardCategory;
-
     private String title;
-
     private String writeDate;
-
     private String nickname;
     private int view;
     private int likedCount;
+    private String authentication;
 
     public BoardMainDto(Board board) {
         this.boardId = board.getId();
@@ -29,9 +26,20 @@ public class BoardMainDto {
         this.likedCount = board.getLikedCount();
         this.view = board.getView();
         this.nickname = board.getMember().getNickname();
+        this.authentication = board.getAuthentication();
     }
+
     @QueryProjection
-    public BoardMainDto(Long boardId, BoardCategory boardCategory, String title, String writeDate, String nickname, int view, int likedCount) {
+    public BoardMainDto(
+            Long boardId,
+            BoardCategory boardCategory,
+            String title,
+            String writeDate,
+            String nickname,
+            int view,
+            int likedCount,
+            String authentication) {
+
         this.boardId = boardId;
         this.boardCategory = boardCategory;
         this.title = title;
@@ -39,6 +47,7 @@ public class BoardMainDto {
         this.nickname = nickname;
         this.view = view;
         this.likedCount = likedCount;
+        this.authentication = authentication;
     }
 
 }

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/dto/board/BoardSortedCase.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/dto/board/BoardSortedCase.java
@@ -10,11 +10,11 @@ public enum BoardSortedCase {
 
     LIKED(1),
 
-    MORETHANFIVELIKED(2),
+    LATEST(2),
 
-    REVIEW(3),
+    VIEW(3),
 
-    VIEW(4);
+    REVIEW(4);
 
     private final int value;
 }

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/dto/restaurantreview/RestaurantReviewDto.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/dto/restaurantreview/RestaurantReviewDto.java
@@ -5,6 +5,7 @@ import ProjectDoge.StudentSoup.entity.member.Member;
 import ProjectDoge.StudentSoup.entity.restaurant.RestaurantReview;
 import lombok.Data;
 
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -32,7 +33,7 @@ public class RestaurantReviewDto {
         this.memberProfileImageName = setProfileImageFileName(restaurantReview.getMember());
         this.nickName = restaurantReview.getMember().getNickname();
         this.content = restaurantReview.getContent();
-        this.writeDate = restaurantReview.getWriteDate().toString();
+        this.writeDate = restaurantReview.getWriteDate().toLocalDate().toString();
         this.starLiked = restaurantReview.getStarLiked();
         this.likedCount = restaurantReview.getLikedCount();
         this.imageFileNameList = setImageFileList(restaurantReview);

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/entity/board/Board.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/entity/board/Board.java
@@ -8,9 +8,9 @@ import ProjectDoge.StudentSoup.entity.member.Member;
 import lombok.Getter;
 import lombok.Setter;
 import org.hibernate.annotations.ColumnDefault;
+import org.hibernate.annotations.DynamicInsert;
 
 import javax.persistence.*;
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
@@ -18,6 +18,7 @@ import java.util.List;
 
 @Entity
 @Table(name = "BOARD")
+@DynamicInsert
 @Getter
 @Setter
 public class Board {

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/entity/board/Board.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/entity/board/Board.java
@@ -7,6 +7,7 @@ import ProjectDoge.StudentSoup.entity.school.School;
 import ProjectDoge.StudentSoup.entity.member.Member;
 import lombok.Getter;
 import lombok.Setter;
+import org.hibernate.annotations.ColumnDefault;
 
 import javax.persistence.*;
 import java.time.LocalDate;
@@ -59,6 +60,9 @@ public class Board {
     private int likedCount;
 
     private String isView;
+
+    @ColumnDefault("'N'")
+    private String authentication;
 
     @OneToMany(mappedBy = "board", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<BoardReview> boardReviews = new ArrayList<>();

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/entity/board/Board.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/entity/board/Board.java
@@ -88,6 +88,7 @@ public class Board {
         this.setMember(member);
         this.setSchool(school);
         this.setDepartment(department);
+        this.setIsView(setViewOption(form.getBoardCategory()));
         return this;
     }
 
@@ -102,6 +103,7 @@ public class Board {
         this.setMember(member);
         this.setSchool(school);
         this.setDepartment(department);
+        this.setIsView(setViewOption(form.getBoardCategory()));
         return this;
     }
 

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/entity/board/Board.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/entity/board/Board.java
@@ -58,6 +58,7 @@ public class Board {
 
     private int likedCount;
 
+    private String isView;
 
     @OneToMany(mappedBy = "board", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<BoardReview> boardReviews = new ArrayList<>();
@@ -114,8 +115,16 @@ public class Board {
         this.setLikedCount(0);
         this.setMember(member);
         this.setSchool(school);
+        this.setIsView(setViewOption(form.getBoardCategory()));
         return this;
     }
+
+    private String setViewOption(BoardCategory category){
+        if(String.valueOf(category).equals("ANNOUNCEMENT"))
+            return "N";
+        return "Y";
+    }
+
     public Board editBoard(BoardFormDto boardFormDto){
         this.setTitle(boardFormDto.getTitle());
         this.setContent(boardFormDto.getContent());

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/entity/restaurant/RestaurantReview.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/entity/restaurant/RestaurantReview.java
@@ -8,6 +8,7 @@ import lombok.Setter;
 
 import javax.persistence.*;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -43,11 +44,11 @@ public class RestaurantReview {
     // 리뷰에서 작성한 음식점의 별점
     private int starLiked;
 
-    @Column(columnDefinition = "DATE")
-    private LocalDate writeDate;
+    @Column(columnDefinition = "TIMESTAMP")
+    private LocalDateTime writeDate;
 
-    @Column(columnDefinition = "DATE")
-    private LocalDate updateDate;
+    @Column(columnDefinition = "TIMESTAMP")
+    private LocalDateTime updateDate;
 
     @OneToMany(mappedBy = "restaurantReview", cascade = CascadeType.REMOVE)
     private List<RestaurantReviewLike> restaurantReviewLikes = new ArrayList<>();
@@ -73,8 +74,8 @@ public class RestaurantReview {
         this.content = dto.getContent();
         this.likedCount = 0;
         this.starLiked = dto.getStarLiked();
-        this.writeDate = LocalDate.now();
-        this.updateDate = LocalDate.now();
+        this.writeDate = LocalDateTime.now();
+        this.updateDate = LocalDateTime.now();
         return this;
     }
 
@@ -83,8 +84,8 @@ public class RestaurantReview {
         restaurantReview.setContent("레스토랑 리뷰 내용");
         restaurantReview.setLikedCount(0);
         restaurantReview.setStarLiked(0);
-        restaurantReview.setWriteDate(LocalDate.now());
-        restaurantReview.setUpdateDate(LocalDate.now());
+        restaurantReview.setWriteDate(LocalDateTime.now());
+        restaurantReview.setUpdateDate(LocalDateTime.now());
 
         return restaurantReview;
     }

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/repository/board/BoardRepositoryCustom.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/repository/board/BoardRepositoryCustom.java
@@ -18,10 +18,6 @@ public interface BoardRepositoryCustom {
 
     Page<BoardMainDto> orderByCategory(Long schoolId, Long departmentId, String category, int sorted, Pageable pageable,String column,String value);
 
-    List<BoardMainDto> findAnnouncement();
-
-    Long countAnnouncement();
-
     List<BoardMainDto> findLiveBestAndHotBoards(Long schoolId, LocalDateTime searchTime,LocalDateTime endDateTime);
 
     List<BoardMainDto> findBestTipBoards(Long schoolId);

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/repository/board/BoardRepositoryCustom.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/repository/board/BoardRepositoryCustom.java
@@ -20,8 +20,6 @@ public interface BoardRepositoryCustom {
 
     List<BoardMainDto> findLiveBestAndHotBoards(Long schoolId, LocalDateTime searchTime,LocalDateTime endDateTime);
 
-    List<BoardMainDto> findBestTipBoards(Long schoolId);
-
     Page<MemberMyPageBoardDto> findByMemberIdForMyPage(Long memberId, Pageable pageable);
 
     Long countByMemberId(Long memberId);

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/repository/board/BoardRepositoryCustom.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/repository/board/BoardRepositoryCustom.java
@@ -18,7 +18,9 @@ public interface BoardRepositoryCustom {
 
     Page<BoardMainDto> orderByCategory(Long schoolId, Long departmentId, String category, int sorted, Pageable pageable,String column,String value);
 
-    List<BoardMainDto>  findAnnouncement();
+    List<BoardMainDto> findAnnouncement();
+
+    Long countAnnouncement();
 
     List<BoardMainDto> findLiveBestAndHotBoards(Long schoolId, LocalDateTime searchTime,LocalDateTime endDateTime);
 

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/repository/board/BoardRepositoryCustom.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/repository/board/BoardRepositoryCustom.java
@@ -18,7 +18,7 @@ public interface BoardRepositoryCustom {
 
     Page<BoardMainDto> orderByCategory(Long schoolId, Long departmentId, String category, int sorted, Pageable pageable,String column,String value);
 
-    Optional<BoardMainDto>  findAnnouncement();
+    List<BoardMainDto>  findAnnouncement();
 
     List<BoardMainDto> findLiveBestAndHotBoards(Long schoolId, LocalDateTime searchTime,LocalDateTime endDateTime);
 

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/repository/board/BoardRepositoryImpl.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/repository/board/BoardRepositoryImpl.java
@@ -84,7 +84,6 @@ public class BoardRepositoryImpl implements BoardRepositoryCustom {
                 .where(
                         checkAnnouncement().or(checkSortedBoard(category))
                                 .and(checkTypeOfBoard(schoolId, departmentId))
-                                .and(checkSortedLiked(sorted))
                                 .and(searchColumnContainsTitle(column, value))
                                 .and(searchColumnContainsContent(column, value))
                                 .and(searchColumnContainsNickname(column, value))
@@ -99,7 +98,6 @@ public class BoardRepositoryImpl implements BoardRepositoryCustom {
                 .from(board)
                 .where(checkAnnouncement().or(checkSortedBoard(category))
                         .and(checkTypeOfBoard(schoolId, departmentId))
-                        .and(checkSortedLiked(sorted))
                         .and(searchColumnContainsTitle(column, value))
                         .and(searchColumnContainsContent(column, value))
                         .and(searchColumnContainsNickname(column, value)));
@@ -178,12 +176,15 @@ public class BoardRepositoryImpl implements BoardRepositoryCustom {
         return Expressions.allOf(categoryCond1, categoryCond2);
     }
 
+    // TODO 차후 인증 글 서비스 추가
+    /*
     private BooleanExpression checkSortedLiked(int sorted) {
         if (BoardSortedCase.MORETHANFIVELIKED.getValue() == sorted) {
             return board.likedCount.goe(5);
         }
         return null;
     }
+    */
 
 
     private OrderSpecifier<?> checkSortedCondition(int sorted) {

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/repository/board/BoardRepositoryImpl.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/repository/board/BoardRepositoryImpl.java
@@ -129,27 +129,6 @@ public class BoardRepositoryImpl implements BoardRepositoryCustom {
         return query;
     }
 
-    @Override
-    public List<BoardMainDto> findBestTipBoards(Long schoolId) {
-        List<BoardMainDto> query = queryFactory
-                .select(new QBoardMainDto(board.id,
-                        board.boardCategory,
-                        board.title,
-                        board.writeDate,
-                        board.member.nickname,
-                        board.view,
-                        board.likedCount,
-                        board.authentication))
-                .from(board)
-                .where(board.school.id.eq(schoolId),
-                        board.boardCategory.eq(BoardCategory.TIP))
-                .orderBy(board.likedCount.desc(), board.writeDate.desc())
-                .offset(0)
-                .limit(4)
-                .fetch();
-        return query;
-    }
-
     private BooleanExpression searchColumnContainsTitle(String column, String value) {
         if (column != null && column.equals("title")) {
             return board.title.contains(value);

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/repository/board/BoardRepositoryImpl.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/repository/board/BoardRepositoryImpl.java
@@ -19,6 +19,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.support.PageableExecutionUtils;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
@@ -98,8 +99,8 @@ public class BoardRepositoryImpl implements BoardRepositoryCustom {
     }
 
     @Override
-    public Optional<BoardMainDto> findAnnouncement(){
-        BoardMainDto query = queryFactory
+    public List<BoardMainDto> findAnnouncement(){
+        return queryFactory
                 .select(new QBoardMainDto(board.id,
                         board.boardCategory,
                         board.title,
@@ -108,12 +109,8 @@ public class BoardRepositoryImpl implements BoardRepositoryCustom {
                         board.view,
                         board.likedCount))
                 .from(board)
-                .where(board.boardCategory.eq(BoardCategory.ANNOUNCEMENT))
-                .offset(0)
-                .limit(1)
-                .fetchOne();
-
-        return Optional.ofNullable(query);
+                .where(board.boardCategory.eq(BoardCategory.ANNOUNCEMENT), board.isView.eq("Y"))
+                .fetch();
     }
 
     @Override

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/repository/board/BoardRepositoryImpl.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/repository/board/BoardRepositoryImpl.java
@@ -7,6 +7,7 @@ import ProjectDoge.StudentSoup.dto.member.MemberMyPageBoardDto;
 import ProjectDoge.StudentSoup.dto.member.QMemberMyPageBoardDto;
 import ProjectDoge.StudentSoup.entity.board.Board;
 import ProjectDoge.StudentSoup.entity.board.BoardCategory;
+import ProjectDoge.StudentSoup.exception.school.SchoolIdNotSentException;
 import com.querydsl.core.types.Expression;
 import com.querydsl.core.types.Order;
 import com.querydsl.core.types.OrderSpecifier;
@@ -150,6 +151,9 @@ public class BoardRepositoryImpl implements BoardRepositoryCustom {
 
 
     private BooleanExpression checkTypeOfBoard(Long schoolId, Long departmentId) {
+        if(schoolId == null){
+            throw new SchoolIdNotSentException("학교 기본키가 전달되지 않았습니다.");
+        }
         BooleanExpression findBySchool = board.school.id.eq(schoolId);
         if (departmentId == null) {
             return findBySchool;

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/repository/board/BoardRepositoryImpl.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/repository/board/BoardRepositoryImpl.java
@@ -151,10 +151,10 @@ public class BoardRepositoryImpl implements BoardRepositoryCustom {
 
     private BooleanExpression checkTypeOfBoard(Long schoolId, Long departmentId) {
         BooleanExpression findBySchool = board.school.id.eq(schoolId);
-        BooleanExpression findByDepartment = board.department.id.eq(departmentId);
         if (departmentId == null) {
             return findBySchool;
         }
+        BooleanExpression findByDepartment = board.department.id.eq(departmentId);
 
         return Expressions.allOf(findBySchool, findByDepartment);
     }

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/repository/board/BoardRepositoryImpl.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/repository/board/BoardRepositoryImpl.java
@@ -114,6 +114,14 @@ public class BoardRepositoryImpl implements BoardRepositoryCustom {
     }
 
     @Override
+    public Long countAnnouncement() {
+        return queryFactory.select(board.count())
+                .from(board)
+                .where(board.boardCategory.eq(BoardCategory.ANNOUNCEMENT), board.isView.eq("Y"))
+                .fetchOne();
+    }
+
+    @Override
     public  List<BoardMainDto>  findLiveBestAndHotBoards(Long schoolId,LocalDateTime searchDate,LocalDateTime EndDate){
         List<BoardMainDto> query = queryFactory
                 .select(new QBoardMainDto(board.id,

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/service/BoardReview/BoardReviewCallService.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/service/BoardReview/BoardReviewCallService.java
@@ -1,6 +1,7 @@
 package ProjectDoge.StudentSoup.service.BoardReview;
 
 
+import ProjectDoge.StudentSoup.commonmodule.ConstField;
 import ProjectDoge.StudentSoup.dto.board.BoardReviewDto;
 import ProjectDoge.StudentSoup.entity.board.BoardLike;
 import ProjectDoge.StudentSoup.entity.board.BoardReview;
@@ -22,10 +23,6 @@ import java.util.concurrent.ConcurrentHashMap;
 @RequiredArgsConstructor
 @Service
 public class BoardReviewCallService {
-
-    boolean boardReviewLiked = true;
-
-    boolean boardReviewNotLiked = false;
     private final BoardReviewRepository boardReviewRepository;
 
     public ConcurrentHashMap<String,Object> callBoardReview(Long memberId,Long boardId, Pageable pageable){
@@ -60,8 +57,8 @@ public class BoardReviewCallService {
     private BoardReviewDto getBoardReviewLike(Long memberId, BoardReview boardReview) {
         for(BoardLike boardLike : boardReview.getBoard().getBoardLikes()){
             if(boardLike.getMember().getMemberId().equals(memberId))
-                return new BoardReviewDto().createBoardReviewDto(boardReview,boardReviewLiked);
+                return new BoardReviewDto().createBoardReviewDto(boardReview, ConstField.LIKED);
         }
-        return new BoardReviewDto().createBoardReviewDto(boardReview,boardReviewNotLiked);
+        return new BoardReviewDto().createBoardReviewDto(boardReview, ConstField.NOT_LIKED);
     }
 }

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/service/BoardReview/BoardReviewLikeService.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/service/BoardReview/BoardReviewLikeService.java
@@ -1,5 +1,6 @@
 package ProjectDoge.StudentSoup.service.BoardReview;
 
+import ProjectDoge.StudentSoup.commonmodule.ConstField;
 import ProjectDoge.StudentSoup.dto.board.BoardReviewDto;
 import ProjectDoge.StudentSoup.entity.board.BoardReview;
 import ProjectDoge.StudentSoup.entity.board.BoardReviewLike;
@@ -17,10 +18,6 @@ import java.util.concurrent.ConcurrentHashMap;
 @Service
 @RequiredArgsConstructor
 public class BoardReviewLikeService {
-        boolean boardReviewLiked =true;
-
-        boolean boardReviewNotLiked = false;
-
         private final BoardReviewLikeRepository boardReviewLikeRepository;
         private final BoardReviewFindService boardReviewFindService;
         private final MemberFindService memberFindService;
@@ -36,16 +33,16 @@ public class BoardReviewLikeService {
             likeBoardReview(boardReview,member,resultMap);
         }
         else{
-            cancelBoardReview(boardReview,boardReviewLike,resultMap);
+            unlikeBoardReview(boardReview,boardReviewLike,resultMap);
         }
 
         return  resultMap;
     }
 
-    private void cancelBoardReview(BoardReview boardReview,BoardReviewLike boardReviewLike, ConcurrentHashMap<String, Object> resultMap) {
+    private void unlikeBoardReview(BoardReview boardReview,BoardReviewLike boardReviewLike, ConcurrentHashMap<String, Object> resultMap) {
         boardReviewLikeRepository.delete(boardReviewLike);
         boardReview.minusLikeCount();
-        BoardReviewDto boardReviewDto = new BoardReviewDto().createBoardReviewDto(boardReview,boardReviewNotLiked);
+        BoardReviewDto boardReviewDto = new BoardReviewDto().createBoardReviewDto(boardReview, ConstField.NOT_LIKED);
         resultMap.put("data",boardReviewDto);
         resultMap.put("result","cancel");
     }
@@ -54,7 +51,7 @@ public class BoardReviewLikeService {
         BoardReviewLike boardReviewLike = new BoardReviewLike().createBoardReviewLike(boardReview,member);
         boardReviewLikeRepository.save(boardReviewLike);
         boardReview.addLikeCount();
-        BoardReviewDto boardReviewDto = new BoardReviewDto().createBoardReviewDto(boardReview,boardReviewLiked);
+        BoardReviewDto boardReviewDto = new BoardReviewDto().createBoardReviewDto(boardReview, ConstField.LIKED);
         resultMap.put("data",boardReviewDto);
         resultMap.put("result","like");
     }

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/service/board/BoardCallService.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/service/board/BoardCallService.java
@@ -66,11 +66,12 @@ public class BoardCallService {
 
     private void getAnnouncement(ConcurrentHashMap<String,Object> map){
         log.info("공지사항 호출 메서드가 실행됐습니다.");
-        Optional<BoardMainDto> announcement = boardRepository.findAnnouncement();
-        if(announcement.get() != null) {
-            setWriteDate(announcement.get());
+
+        List<BoardMainDto> announcement = boardRepository.findAnnouncement();
+        for(BoardMainDto dto : announcement){
+            setWriteDate(dto);
         }
-        map.put("announcement",announcement);
+        map.put("announcements", announcement);
     }
 
     private void getBoards(BoardCallDto boardCallDto,
@@ -115,7 +116,7 @@ public class BoardCallService {
                                       String category,
                                       int sorted,
                                       BoardSearchDto boardSearchDto) {
-        log.info("팁 게시판 0페이지 호출 메서드가 싷행 됐습니다.");
+        log.info("팁 게시판 0페이지 호출 메서드가 실행 됐습니다.");
         PageRequest pageable = PageRequest.of(0, 8);
 
         Page<BoardMainDto> boards = boardRepository.orderByCategory(boardCallDto.getSchoolId(),

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/service/board/BoardCallService.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/service/board/BoardCallService.java
@@ -29,7 +29,7 @@ public class BoardCallService {
     private final BoardFindService boardFindService;
     private final BoardRepository boardRepository;
     private  final BoardLikeRepository boardLikeRepository;
-    boolean boardLiked =true;
+    boolean boardLiked = true;
     boolean boardNotLiked = false;
 
 

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/service/board/BoardCallService.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/service/board/BoardCallService.java
@@ -1,5 +1,6 @@
 package ProjectDoge.StudentSoup.service.board;
 
+import ProjectDoge.StudentSoup.commonmodule.ConstField;
 import ProjectDoge.StudentSoup.dto.board.BoardCallDto;
 import ProjectDoge.StudentSoup.dto.board.BoardDto;
 import ProjectDoge.StudentSoup.dto.board.BoardMainDto;
@@ -29,9 +30,6 @@ public class BoardCallService {
     private final BoardFindService boardFindService;
     private final BoardRepository boardRepository;
     private  final BoardLikeRepository boardLikeRepository;
-    boolean boardLiked = true;
-    boolean boardNotLiked = false;
-
 
     public BoardDto getBoardDetail(Long boardId,Long memberId){
         log.info("게시글 클릭시 게시글 호출 로직이 실행되었습니다.");
@@ -177,11 +175,11 @@ public class BoardCallService {
     }
 
     private BoardDto getLikeBoardDto(Board board) {
-        return new BoardDto(board,boardLiked);
+        return new BoardDto(board, ConstField.LIKED);
     }
 
     private BoardDto getNotLikeBoardDto(Board board) {
-        return new BoardDto(board,boardNotLiked);
+        return new BoardDto(board, ConstField.NOT_LIKED);
     }
 
     private void checkWriteDate(Page<BoardMainDto> boardMainDtoList) {

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/service/board/BoardLikeService.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/service/board/BoardLikeService.java
@@ -24,10 +24,7 @@ public class BoardLikeService {
     private final MemberFindService memberFindService;
 
     private  final BoardFindService boardFindService;
-
-    boolean boardLiked =true;
-
-    boolean boardNotLiked = false;
+    
 
     @Transactional
     public ConcurrentHashMap<String,Object> boardLike(Long boardId,Long memberId){
@@ -47,13 +44,13 @@ public class BoardLikeService {
     }
 
     private void unLikeBoard(BoardLike boardLike,Board board, ConcurrentHashMap<String, Object> resultMap) {
-        log.info("게시글 삭제 서비스 로직이 실행되었습니다.");
+        log.info("좋아요 취소 서비스 로직이 실행되었습니다.");
         boardLikeRepository.delete(boardLike);
         board.minusLikeCount();
         BoardDto dto = new BoardDto(board, ConstField.NOT_LIKED);
-        resultMap.put("data",dto);
-        resultMap.put("result","cancel");
-        log.info("게시글 좋아요가 삭제되었습니다.");
+        resultMap.put("data", dto);
+        resultMap.put("result", "cancel");
+        log.info("게시글 좋아요가 취소 되었습니다.");
     }
 
     private void likeBoard(Member member,Board board,ConcurrentHashMap<String,Object> resultMap) {

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/service/board/BoardLikeService.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/service/board/BoardLikeService.java
@@ -1,5 +1,6 @@
 package ProjectDoge.StudentSoup.service.board;
 
+import ProjectDoge.StudentSoup.commonmodule.ConstField;
 import ProjectDoge.StudentSoup.dto.board.BoardDto;
 import ProjectDoge.StudentSoup.entity.board.Board;
 import ProjectDoge.StudentSoup.entity.board.BoardLike;
@@ -40,17 +41,16 @@ public class BoardLikeService {
             return resultMap;
         }
         else{
-            cancelLike(boardLike,board,resultMap);
-            return  resultMap;
+            unLikeBoard(boardLike,board,resultMap);
+            return resultMap;
         }
     }
 
-
-    private void cancelLike(BoardLike boardLike,Board board, ConcurrentHashMap<String, Object> resultMap) {
+    private void unLikeBoard(BoardLike boardLike,Board board, ConcurrentHashMap<String, Object> resultMap) {
         log.info("게시글 삭제 서비스 로직이 실행되었습니다.");
         boardLikeRepository.delete(boardLike);
         board.minusLikeCount();
-        BoardDto dto = new BoardDto(board,boardNotLiked);
+        BoardDto dto = new BoardDto(board, ConstField.NOT_LIKED);
         resultMap.put("data",dto);
         resultMap.put("result","cancel");
         log.info("게시글 좋아요가 삭제되었습니다.");
@@ -61,9 +61,9 @@ public class BoardLikeService {
         BoardLike boardLike = new BoardLike().createBoard(member,board);
         boardLikeRepository.save(boardLike);
         board.addLikeCount();
-        BoardDto dto = new BoardDto(board,boardLiked);
-        resultMap.put("data",dto);
-        resultMap.put("result","like");
+        BoardDto dto = new BoardDto(board, ConstField.LIKED);
+        resultMap.put("data", dto);
+        resultMap.put("result", "like");
         log.info("게시글 좋아요가 저장되었습니다.");
     }
 }

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/service/board/BoardResisterService.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/service/board/BoardResisterService.java
@@ -48,7 +48,7 @@ public class BoardResisterService {
         Board board = createBoard(boardFormDto.getDepartmentId(), boardFormDto, member);
         uploadBoardImage(uploadFileDtoList, board);
         boardRepository.save(board);
-        log.info("게시글이 저장되었습니다.[{}]",board.getId());
+        log.info("게시글이 저장되었습니다.[{}]", board.getId());
         return board.getId();
     }
 
@@ -58,7 +58,7 @@ public class BoardResisterService {
         List<BoardCategoryDto> categoryDtoList = new ArrayList<>();
         for (BoardCategory category : BoardCategory.values()){
             categoryDtoList.add(new BoardCategoryDto(String.valueOf(category), category.getBoardCategory()));
-            log.info("boardCategory [{}], boardCategory [{}]",category.getBoardCategory(),category.name());
+            log.info("boardCategory [{}], boardCategory [{}]", category.getBoardCategory(), category.name());
     }
         if(!member.getMemberClassification().equals(MemberClassification.ADMIN))
             categoryDtoList.remove(categoryDtoList.size() - 1);
@@ -78,7 +78,7 @@ public class BoardResisterService {
     }
 
     private void checkQualification(BoardFormDto boardFormDto, Member member) {
-        if(boardFormDto.getBoardCategory() == BoardCategory.ANNOUNCEMENT && member.getMemberClassification()!= MemberClassification.ADMIN){
+        if(boardFormDto.getBoardCategory() == BoardCategory.ANNOUNCEMENT && member.getMemberClassification() != MemberClassification.ADMIN){
             throw new BoardNotQualifiedException("공지사항은 관리자만 작성 가능합니다.");
         }
     }
@@ -92,20 +92,20 @@ public class BoardResisterService {
     }
 
     @Transactional
-    public  Long join(Long memberId,BoardFormDto boardFormDto){
+    public Long join(Long memberId,BoardFormDto boardFormDto){
         log.info("게시글 생성 메소드가 실행되었습니다");
         Member member = memberFindService.findOne(memberId);
-        Board board = new Board().createBoard(boardFormDto,member, member.getSchool(),member.getDepartment());
+        Board board = new Board().createBoard(boardFormDto, member, member.getSchool(), member.getDepartment());
         boardRepository.save(board);
         log.info("게시글이 저장되었습니다.[{}]",board.getId());
         return board.getId();
     }
 
     @Transactional
-    public  Long testJoin(Long memberId,BoardFormDto boardFormDto){
+    public Long testJoin(Long memberId,BoardFormDto boardFormDto){
         log.info("게시글 생성 메소드가 실행되었습니다");
         Member member = memberFindService.findOne(memberId);
-        Board board = new Board().createTestBoard(boardFormDto,member, member.getSchool(),member.getDepartment());
+        Board board = new Board().createTestBoard(boardFormDto, member, member.getSchool(), member.getDepartment());
         boardRepository.save(board);
         log.info("게시글이 저장되었습니다.[{}]",board.getId());
         return board.getId();

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/service/restaurant/RestaurantCallService.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/service/restaurant/RestaurantCallService.java
@@ -1,6 +1,7 @@
 package ProjectDoge.StudentSoup.service.restaurant;
 
 
+import ProjectDoge.StudentSoup.commonmodule.ConstField;
 import ProjectDoge.StudentSoup.dto.restaurant.RestaurantDto;
 import ProjectDoge.StudentSoup.dto.school.SchoolResponseDto;
 import ProjectDoge.StudentSoup.entity.restaurant.Restaurant;
@@ -27,9 +28,6 @@ public class RestaurantCallService {
 
     private final RestaurantRepository restaurantRepository;
     private final SchoolFindService schoolFindService;
-
-    boolean restaurantLiked = true;
-    boolean restaurantNotLiked = false;
 
     public ConcurrentHashMap<String, Object> restaurantSortedCall(Long schoolId,
                                                                   String schoolName,
@@ -98,11 +96,11 @@ public class RestaurantCallService {
     }
 
     private RestaurantDto getLikeRestaurantDto(Restaurant restaurant) {
-        return new RestaurantDto().createRestaurantDto(restaurant, restaurantLiked);
+        return new RestaurantDto().createRestaurantDto(restaurant, ConstField.LIKED);
     }
 
     private RestaurantDto getNotLikeRestaurantDto(Restaurant restaurant) {
-        return new RestaurantDto().createRestaurantDto(restaurant, restaurantNotLiked);
+        return new RestaurantDto().createRestaurantDto(restaurant, ConstField.NOT_LIKED);
     }
 
     private ConcurrentHashMap<String, Object> getNotLoginRestaurantList(List<Restaurant> restaurants,

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/service/restaurant/RestaurantDetailCallService.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/service/restaurant/RestaurantDetailCallService.java
@@ -1,5 +1,6 @@
 package ProjectDoge.StudentSoup.service.restaurant;
 
+import ProjectDoge.StudentSoup.commonmodule.ConstField;
 import ProjectDoge.StudentSoup.dto.restaurant.RestaurantDetailDto;
 import ProjectDoge.StudentSoup.dto.restaurantmenu.RestaurantMenuDto;
 import ProjectDoge.StudentSoup.entity.restaurant.Restaurant;
@@ -29,9 +30,6 @@ import java.util.concurrent.ConcurrentHashMap;
 public class RestaurantDetailCallService {
     private final RestaurantFindService restaurantFindService;
     private final RestaurantLikeRepository restaurantLikeRepository;
-
-    private final boolean LIKED = true;
-    private final boolean NOT_LIKED = false;
 
     @Transactional
     public ConcurrentHashMap<String, Object> restaurantDetailCall(Long restaurantId, Long memberId){
@@ -103,12 +101,12 @@ public class RestaurantDetailCallService {
     }
 
     private void getLikeRestaurantDto(ConcurrentHashMap<String, Object> resultMap, Restaurant restaurant) {
-        RestaurantDetailDto dto = new RestaurantDetailDto().createRestaurantDetailDto(restaurant, LIKED);
+        RestaurantDetailDto dto = new RestaurantDetailDto().createRestaurantDetailDto(restaurant, ConstField.LIKED);
         resultMap.put("restaurant", dto);
     }
 
     private void getNotLikeRestaurantDto(ConcurrentHashMap<String, Object> resultMap, Restaurant restaurant) {
-        RestaurantDetailDto dto = new RestaurantDetailDto().createRestaurantDetailDto(restaurant, NOT_LIKED);
+        RestaurantDetailDto dto = new RestaurantDetailDto().createRestaurantDetailDto(restaurant, ConstField.NOT_LIKED);
         resultMap.put("restaurant", dto);
     }
 }

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/service/restaurant/RestaurantLikeService.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/service/restaurant/RestaurantLikeService.java
@@ -1,5 +1,6 @@
 package ProjectDoge.StudentSoup.service.restaurant;
 
+import ProjectDoge.StudentSoup.commonmodule.ConstField;
 import ProjectDoge.StudentSoup.dto.restaurant.RestaurantDto;
 import ProjectDoge.StudentSoup.entity.member.Member;
 import ProjectDoge.StudentSoup.entity.restaurant.Restaurant;
@@ -22,9 +23,6 @@ public class RestaurantLikeService {
     private final RestaurantLikeRepository restaurantLikeRepository;
     private final RestaurantFindService restaurantFindService;
     private final MemberFindService memberFindService;
-
-    boolean restaurantLiked = true;
-    boolean restaurantNotLiked = false;
 
     @Transactional
     public ConcurrentHashMap<String, Object> restaurantLike(Long restaurantId, Long memberId) {
@@ -68,7 +66,7 @@ public class RestaurantLikeService {
         restaurantLikeRepository.deleteById(restaurantLikeId);
         restaurant.minusLikedCount();
 
-        RestaurantDto dto = new RestaurantDto().createRestaurantDto(restaurant, restaurantNotLiked);
+        RestaurantDto dto = new RestaurantDto().createRestaurantDto(restaurant, ConstField.NOT_LIKED);
         resultMap.put("data", dto);
         resultMap.put("result", "cancel");
 
@@ -81,7 +79,7 @@ public class RestaurantLikeService {
         restaurantLikeRepository.save(restaurantLike);
         restaurant.addLikedCount();
 
-        RestaurantDto dto = new RestaurantDto().createRestaurantDto(restaurant, restaurantLiked);
+        RestaurantDto dto = new RestaurantDto().createRestaurantDto(restaurant, ConstField.LIKED);
         resultMap.put("data", dto);
         resultMap.put("result", "like");
 

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/service/restaurantmenu/RestaurantMenuCallService.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/service/restaurantmenu/RestaurantMenuCallService.java
@@ -1,5 +1,6 @@
 package ProjectDoge.StudentSoup.service.restaurantmenu;
 
+import ProjectDoge.StudentSoup.commonmodule.ConstField;
 import ProjectDoge.StudentSoup.dto.restaurantmenu.RestaurantMenuDto;
 import ProjectDoge.StudentSoup.entity.restaurant.RestaurantMenu;
 import ProjectDoge.StudentSoup.entity.restaurant.RestaurantMenuLike;
@@ -22,9 +23,6 @@ import java.util.List;
 public class RestaurantMenuCallService {
 
     private final RestaurantMenuRepository restaurantMenuRepository;
-
-    private final boolean LIKED = true;
-    private final boolean NOT_LIKED = false;
 
     @Transactional
     public Page<RestaurantMenuDto> restaurantMenuCall(Long restaurantId, Long memberId, Pageable pageable){
@@ -85,10 +83,10 @@ public class RestaurantMenuCallService {
     }
 
     private RestaurantMenuDto getNotLikeRestaurantMenuDto(RestaurantMenu restaurantMenu){
-        return new RestaurantMenuDto().createRestaurantMenu(restaurantMenu, NOT_LIKED);
+        return new RestaurantMenuDto().createRestaurantMenu(restaurantMenu, ConstField.NOT_LIKED);
     }
 
     private RestaurantMenuDto getLikeRestaurantMenuDto(RestaurantMenu restaurantMenu){
-        return new RestaurantMenuDto().createRestaurantMenu(restaurantMenu, LIKED);
+        return new RestaurantMenuDto().createRestaurantMenu(restaurantMenu, ConstField.LIKED);
     }
 }

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/service/restaurantmenu/RestaurantMenuLikeService.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/service/restaurantmenu/RestaurantMenuLikeService.java
@@ -1,5 +1,6 @@
 package ProjectDoge.StudentSoup.service.restaurantmenu;
 
+import ProjectDoge.StudentSoup.commonmodule.ConstField;
 import ProjectDoge.StudentSoup.dto.restaurantmenu.RestaurantMenuDto;
 import ProjectDoge.StudentSoup.entity.member.Member;
 import ProjectDoge.StudentSoup.entity.restaurant.RestaurantMenu;
@@ -22,9 +23,6 @@ public class RestaurantMenuLikeService {
     private final RestaurantMenuLikeRepository restaurantMenuLikeRepository;
     private final RestaurantMenuFindService restaurantMenuFindService;
     private final MemberFindService memberFindService;
-
-    boolean restaurantMenuLiked = true;
-    boolean restaurantMenuNotLiked = false;
 
     @Transactional
     public ConcurrentHashMap<String, Object> restaurantMenuLike(Long restaurantMenuId, Long memberId){
@@ -67,7 +65,7 @@ public class RestaurantMenuLikeService {
         restaurantMenuLikeRepository.deleteById(restaurantLikeId);
         restaurantMenu.minusLikedCount();
 
-        RestaurantMenuDto dto = new RestaurantMenuDto().createRestaurantMenu(restaurantMenu, restaurantMenuNotLiked);
+        RestaurantMenuDto dto = new RestaurantMenuDto().createRestaurantMenu(restaurantMenu, ConstField.NOT_LIKED);
         resultMap.put("data", dto);
         resultMap.put("result", "cancel");
 
@@ -81,7 +79,7 @@ public class RestaurantMenuLikeService {
         restaurantMenuLikeRepository.save(restaurantMenuLike);
         restaurantMenu.addLikedCount();
 
-        RestaurantMenuDto dto = new RestaurantMenuDto().createRestaurantMenu(restaurantMenu, restaurantMenuLiked);
+        RestaurantMenuDto dto = new RestaurantMenuDto().createRestaurantMenu(restaurantMenu, ConstField.LIKED);
         resultMap.put("data", dto);
         resultMap.put("result", "like");
 

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/service/restaurantreview/RestaurantReviewCallService.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/service/restaurantreview/RestaurantReviewCallService.java
@@ -1,5 +1,6 @@
 package ProjectDoge.StudentSoup.service.restaurantreview;
 
+import ProjectDoge.StudentSoup.commonmodule.ConstField;
 import ProjectDoge.StudentSoup.dto.restaurantreview.RestaurantReviewDto;
 import ProjectDoge.StudentSoup.entity.restaurant.RestaurantReview;
 import ProjectDoge.StudentSoup.entity.restaurant.RestaurantReviewLike;
@@ -22,9 +23,6 @@ import java.util.List;
 public class RestaurantReviewCallService {
 
     private final RestaurantReviewRepository restaurantReviewRepository;
-
-    private final boolean LIKED = true;
-    private final boolean NOT_LIKED = false;
 
     @Transactional
     public Page<RestaurantReviewDto> getRestaurantReviewCall(Long restaurantId,
@@ -69,11 +67,11 @@ public class RestaurantReviewCallService {
     }
 
     private RestaurantReviewDto getLikeRestaurantReviewDto(RestaurantReview restaurantReview){
-        return new RestaurantReviewDto(restaurantReview, LIKED);
+        return new RestaurantReviewDto(restaurantReview, ConstField.LIKED);
     }
 
     private RestaurantReviewDto getNotLikeRestaurantReviewDto(RestaurantReview restaurantReview){
-        return new RestaurantReviewDto(restaurantReview, NOT_LIKED);
+        return new RestaurantReviewDto(restaurantReview, ConstField.NOT_LIKED);
     }
 
     private Page<RestaurantReviewDto> getNotLoginRestaurantReviewList(List<RestaurantReview> sortedRestaurantReviews,

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/service/restaurantreview/RestaurantReviewLikeService.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/service/restaurantreview/RestaurantReviewLikeService.java
@@ -1,5 +1,6 @@
 package ProjectDoge.StudentSoup.service.restaurantreview;
 
+import ProjectDoge.StudentSoup.commonmodule.ConstField;
 import ProjectDoge.StudentSoup.dto.restaurantreview.RestaurantReviewDto;
 import ProjectDoge.StudentSoup.entity.member.Member;
 import ProjectDoge.StudentSoup.entity.restaurant.RestaurantReview;
@@ -22,9 +23,6 @@ public class RestaurantReviewLikeService {
     private final RestaurantReviewLikeRepository restaurantReviewLikeRepository;
     private final RestaurantReviewFindService restaurantReviewFindService;
     private final MemberFindService memberFindService;
-
-    boolean restaurantReviewLiked = true;
-    boolean restaurantReviewNotLiked = false;
 
     @Transactional
     public ConcurrentHashMap<String, Object> restaurantReviewLike(Long restaurantReviewId, Long memberId){
@@ -67,7 +65,7 @@ public class RestaurantReviewLikeService {
         restaurantReviewLikeRepository.deleteById(restaurantReviewLikeId);
         restaurantReview.minusLikedCount();
 
-        RestaurantReviewDto dto = new RestaurantReviewDto(restaurantReview, restaurantReviewNotLiked);
+        RestaurantReviewDto dto = new RestaurantReviewDto(restaurantReview, ConstField.NOT_LIKED);
         resultMap.put("data", dto);
         resultMap.put("result", "cancel");
 
@@ -81,7 +79,7 @@ public class RestaurantReviewLikeService {
         restaurantReviewLikeRepository.save(restaurantReviewLike);
         restaurantReview.addLikedCount();
 
-        RestaurantReviewDto dto = new RestaurantReviewDto(restaurantReview, restaurantReviewLiked);
+        RestaurantReviewDto dto = new RestaurantReviewDto(restaurantReview, ConstField.LIKED);
         resultMap.put("data", dto);
         resultMap.put("result", "like");
 


### PR DESCRIPTION
## 1. Changes
- 공지사항 노출 여부를 확인하기 위한 게시판 엔티티에 `isView` 필드를 추가하였습니다.
- 게시판 호출 시 **category 및 정렬에 대한 기본 값을 추가**하였습니다.
- 공지사항을 호출하는 쿼리문을 수정하였습니다.
- 공지사항을 `isView`(노출 상태)에 따라 호출 할 수 있도록 서비스 로직을 수정하였습니다.
- **좋아요, 좋아요 취소에 대한 공통 상수**를 추가하여 가독성을 높였습니다.
- `TIP 게시판`에 인증 글에 대한 여부를 확인하기 위한 `Board` 엔티티에 `authentication` 필드를 추가하였습니다.
## 2. Screenshot

-

## 3. Issues

1. 게시판 카테고리의 공지사항과 best 게시글을 한 번에 가져오는 것을 시도하였다. 
```java
public Page<BoardMainDto> orderByCategory(Long schoolId,
                                              Long departmentId,
                                              String category,
                                              int sorted,
                                              Pageable pageable,
                                              String column,
                                              String value) {
        List<BoardMainDto> query = queryFactory
                .select(new QBoardMainDto(board.id,
                        board.boardCategory,
                        board.title,
                        board.writeDate,
                        board.member.nickname,
                        board.view,
                        board.likedCount))
                .from(board)
                .where(
                        checkAnnouncement().and(checkSortedBoard(category))
                                .and(checkTypeOfBoard(schoolId, departmentId))
                                .and(checkSortedLiked(sorted))
                                .and(searchColumnContainsTitle(column, value))
                                .and(searchColumnContainsContent(column, value))
                                .and(searchColumnContainsNickname(column, value))
                )
                .orderBy(priorOrderAnnouncement(), checkSortedCondition(sorted))
                .offset(pageable.getOffset())
                .limit(pageable.getPageSize())
                .fetch();
``` 

`checkAnnouncement()` 를 만들어서, `category`가 공지사항이면서, `isView`가 `Y`인 상태의 게시글을 동시에 가져오려고 하였으나,
`ALL`일 경우애는 `Category`가 `Announcement`가 **아닌 내용들을 한 번에** 가져와야 하는데, 조건이 이상하다.
~카테고리가 공지사항 이거나, 공지사항이 아닌 것을 가져온다. 
카테고리가 공지사항 이고, 공지사항 아닌것을 가져온다.
두 개 모두 말이 성립이 되지 않는다. 따라서, 다른 시도가 필요하다.~

**OR 문이기 때문에, 사실 상 둘 다 적용된 다는 것을 머리가 혼란스러워서 헷갈렸던 것 같다. OR 이면 둘다 가능하다는 것을..**
### 최종 쿼리문은 다음과 같다.
```java
List<BoardMainDto> query = queryFactory
                .select(new QBoardMainDto(board.id,
                        board.boardCategory,
                        board.title,
                        board.writeDate,
                        board.member.nickname,
                        board.view,
                        board.likedCount,
                        board.authentication))
                .from(board)
                .where(
                        checkAnnouncement().or(checkSortedBoard(category))
                                .and(checkTypeOfBoard(schoolId, departmentId))
                                .and(checkSortedLiked(sorted))
                                .and(searchColumnContainsTitle(column, value))
                                .and(searchColumnContainsContent(column, value))
                                .and(searchColumnContainsNickname(column, value))
                )
                .orderBy(priorOrderAnnouncement(), priorTipBest(), checkSortedCondition(sorted))
                .offset(pageable.getOffset())
                .limit(pageable.getPageSize())
                .fetch();

        JPQLQuery<Long> count = queryFactory
                .select(board.count())
                .from(board)
                .where(checkAnnouncement().or(checkSortedBoard(category))
                        .and(checkTypeOfBoard(schoolId, departmentId))
                        .and(checkSortedLiked(sorted))
                        .and(searchColumnContainsTitle(column, value))
                        .and(searchColumnContainsContent(column, value))
                        .and(searchColumnContainsNickname(column, value)));

        return PageableExecutionUtils.getPage(query, pageable, count::fetchOne);
```

2. ![Image](https://user-images.githubusercontent.com/74203371/216382625-c9879a96-5718-4234-b60a-632a683021fd.png)

쿼리문을 수정하기 위해 하나 하나 잘라서 시도하던 중에 `학과 id`를 보내지 않을 때는 정상적으로 호출 되는 모습을 볼 수 있었다.
확인해보니 위와 같이 학과 아이디에 대한 점검을 학교 아이디로 시도하고 있으니 당연하게도 안될 수 밖에 없던 문제였다.
안 될 때는 차근차근 잘라보자.

3. 게시글 호출 시 **정렬에 대한 순서가 중요**했다. 우선 **모든 카테고리**에서 `공지사항이 제일 우선순위`가 되어야 한다. 
**팁 게시판**일 경우에는 `공지사항 -> 인증글` 순서이고,
그 외의 경우에는 `sorted` 파라미터에 따라 **정렬의 순서가 정해져야 할 것** 이다.
따라서, `orderBy` 문은 다음과 같이 구성되었다.
```java
.orderBy(priorOrderAnnouncement(), priorTipBest(), checkSortedCondition(sorted))
```

기존에 작성된 동적 정렬 코드를 제외하고 하나씩 뜯어보면 다음과 같다.
```java
private OrderSpecifier<?> priorOrderAnnouncement() {
        NumberExpression<Integer> cases = new CaseBuilder()
                .when(board.boardCategory.eq(BoardCategory.ANNOUNCEMENT))
                .then(1)
                .otherwise(2);

        return new OrderSpecifier<>(Order.ASC, cases);
    }

    private OrderSpecifier<?> priorTipBest() {
        NumberExpression<Integer> cases = new CaseBuilder()
                .when(board.authentication.eq("Y"))
                .then(1)
                .otherwise(2);

        return new OrderSpecifier<>(Order.ASC, cases);
    }
```
필요한 필드에 우선 순위를 주어 우선 순위에 맞게 호출을 할 수 있었다.
결과적으로 예상한 것과 같이 데이터를 호출하는 것을 확인 할 수 있었다.

4. 게시판에 `authentication` 필드를 추가하면서 default 값을 `N` 으로 주기 위해서 `@ColumnDefault("'N'")` 애노테이션을 등록하였다. 그러나 실제로 필드에는 NULL 값이 들어가게 되었는데, 검색 결과 다음과 같았다.
`create문을 자동 생성해줄 때 그 역할이 적용` 그러나 현재 ddl-auto : create 임에도 동작하지 않는 것으로 보아서는, 다른 문제가 있는 것 같다. 
결론적으로는 Table에 `@DynamicInsert` 애노테이션을 추가해주면, 데이터를 집어넣을 때 `null` 값의 필드는 추가하지 않고, `hibernate`가 알아서 `Default` 값을 넣어주는 것을 확인할 수 있었다.

## 4. To Reviewer

-

## 5. Plans
- [x] - 첫 페이지 일 시 공지사항 및 BEST 글 호출되고 남은 수 만큼 호출 로직 추가
- [x] - 게시판 서비스 로직 리팩토링