### PR TITLE
mjw/fixBoard

### DIFF
--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/dto/board/BoardDto.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/dto/board/BoardDto.java
@@ -7,6 +7,8 @@ import ProjectDoge.StudentSoup.entity.member.Member;
 import lombok.Getter;
 import lombok.Setter;
 
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -39,8 +41,8 @@ public class BoardDto {
         this.fileNames = setBoardImageFileNames(board);
         this.nickname = board.getMember().getNickname();
         this.view = board.getView();
-        this.writeDate = board.getWriteDate();
-        this.updateDate = board.getUpdateDate();
+        this.writeDate = board.getWriteDate().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm"));
+        this.updateDate = board.getUpdateDate().toString();
         this.reviewCount = board.getBoardReplies().size();
         this.likedCount = board.getLikedCount();
         this.memberProfileImageName = setProfileImageFileName(board.getMember());

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/dto/board/BoardMainDto.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/dto/board/BoardMainDto.java
@@ -6,6 +6,9 @@ import com.querydsl.core.annotations.QueryProjection;
 import lombok.Getter;
 import lombok.Setter;
 
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
 @Getter
 @Setter
 public class BoardMainDto {
@@ -24,7 +27,7 @@ public class BoardMainDto {
         this.boardId = board.getId();
         this.boardCategory = board.getBoardCategory().getBoardCategory();
         this.title = board.getTitle();
-        this.writeDate = board.getWriteDate();
+        this.writeDate = board.getWriteDate().toLocalDate().toString();
         this.likedCount = board.getLikedCount();
         this.view = board.getView();
         this.nickname = board.getMember().getNickname();
@@ -36,7 +39,7 @@ public class BoardMainDto {
             Long boardId,
             BoardCategory boardCategory,
             String title,
-            String writeDate,
+            LocalDateTime writeDate,
             String nickname,
             int view,
             int likedCount,
@@ -47,7 +50,7 @@ public class BoardMainDto {
         this.boardCategory = boardCategory.getBoardCategory();
         this.tag = replaceCategory(boardCategory.getBoardCategory());
         this.title = title;
-        this.writeDate = writeDate;
+        this.writeDate = writeDate.format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm"));;
         this.nickname = nickname;
         this.view = view;
         this.likedCount = likedCount;

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/dto/boardreply/BoardReplyDto.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/dto/boardreply/BoardReplyDto.java
@@ -5,6 +5,8 @@ import ProjectDoge.StudentSoup.entity.member.Member;
 import lombok.Getter;
 import lombok.Setter;
 
+import java.time.format.DateTimeFormatter;
+
 @Getter
 @Setter
 public class BoardReplyDto {
@@ -26,7 +28,7 @@ public class BoardReplyDto {
         this.boardReplyId = boardReply.getReplyId();
         this.content = boardReply.getContent();
         this.likeCount = boardReply.getLikedCount();
-        this.writeDate = boardReply.getWriteDate();
+        this.writeDate = boardReply.getWriteDate().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm"));;
         this.seq = boardReply.getSeq();
         this.depth = boardReply.getDepth();
         this.level = boardReply.getLevel();

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/dto/member/MemberMyPageBoardDto.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/dto/member/MemberMyPageBoardDto.java
@@ -3,6 +3,9 @@ package ProjectDoge.StudentSoup.dto.member;
 import com.querydsl.core.annotations.QueryProjection;
 import lombok.Data;
 
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
 @Data
 public class MemberMyPageBoardDto {
 
@@ -17,10 +20,10 @@ public class MemberMyPageBoardDto {
     }
 
     @QueryProjection
-    public MemberMyPageBoardDto(Long boardId, String title, String writeDate, int likedCount, int viewCount){
+    public MemberMyPageBoardDto(Long boardId, String title, LocalDateTime writeDate, int likedCount, int viewCount){
         this.boardId = boardId;
         this.title = title;
-        this.writeDate = writeDate;
+        this.writeDate = writeDate.format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm"));;
         this.likedCount = likedCount;
         this.viewCount = viewCount;
     }

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/dto/member/MemberMyPageBoardReplyDto.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/dto/member/MemberMyPageBoardReplyDto.java
@@ -3,6 +3,8 @@ package ProjectDoge.StudentSoup.dto.member;
 import com.querydsl.core.annotations.QueryProjection;
 import lombok.Data;
 
+import java.time.LocalDateTime;
+
 
 @Data
 public class MemberMyPageBoardReplyDto {
@@ -16,10 +18,10 @@ public class MemberMyPageBoardReplyDto {
     }
 
     @QueryProjection
-    public MemberMyPageBoardReplyDto(Long boardId, String content, String writeDate, int likedCount){
+    public MemberMyPageBoardReplyDto(Long boardId, String content, LocalDateTime writeDate, int likedCount){
         this.boardId = boardId;
         this.content = content;
-        this.writeDate = writeDate;
+        this.writeDate = writeDate.toString();
         this.likedCount = likedCount;
     }
 }

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/entity/board/Board.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/entity/board/Board.java
@@ -56,9 +56,11 @@ public class Board {
 
     private int view;
 
-    private String writeDate;
+    @Column(columnDefinition = "TIMESTAMP")
+    private LocalDateTime writeDate;
 
-    private String updateDate;
+    @Column(columnDefinition = "TIMESTAMP")
+    private LocalDateTime updateDate;
 
     private int likedCount;
 
@@ -89,8 +91,8 @@ public class Board {
     public Board createBoard(BoardFormDto form, Member member, School school, Department department) {
         this.setTitle(form.getTitle());
         this.setBoardCategory(form.getBoardCategory());
-        this.setWriteDate(dateFormat(LocalDateTime.now()));
-        this.setUpdateDate(dateFormat(LocalDateTime.now()));
+        this.setWriteDate(LocalDateTime.now());
+        this.setUpdateDate(LocalDateTime.now());
         this.setContent(form.getContent());
         this.setIp(form.getIp());
         this.setView(0);
@@ -105,8 +107,8 @@ public class Board {
     public Board createTestBoard(BoardFormDto form, Member member, School school, Department department) {
         this.setTitle(form.getTitle());
         this.setBoardCategory(form.getBoardCategory());
-        this.setWriteDate(dateFormat(LocalDateTime.now()));
-        this.setUpdateDate(dateFormat(LocalDateTime.now()));
+        this.setWriteDate(LocalDateTime.now());
+        this.setUpdateDate(LocalDateTime.now());
         this.setContent(form.getContent());
         this.setView(0);
         this.setLikedCount(10);
@@ -120,8 +122,8 @@ public class Board {
     public Board createBoard(BoardFormDto form, Member member, School school) {
         this.setTitle(form.getTitle());
         this.setBoardCategory(form.getBoardCategory());
-        this.setWriteDate(dateFormat(LocalDateTime.now()));
-        this.setUpdateDate(dateFormat(LocalDateTime.now()));
+        this.setWriteDate(LocalDateTime.now());
+        this.setUpdateDate(LocalDateTime.now());
         this.setContent(form.getContent());
         this.setView(0);
         this.setLikedCount(0);
@@ -142,7 +144,7 @@ public class Board {
         this.setContent(boardFormDto.getContent());
         updateDepartment(department);
         this.setBoardCategory(boardFormDto.getBoardCategory());
-        this.setUpdateDate(dateFormat(LocalDateTime.now()));
+        this.setUpdateDate(LocalDateTime.now());
         return this;
     }
 
@@ -156,8 +158,8 @@ public class Board {
         this.setContent("내용");
         this.setIp("ip");
         this.setView(0);
-        this.setWriteDate(dateFormat(LocalDateTime.now()));
-        this.setUpdateDate(dateFormat(LocalDateTime.now()));
+        this.setWriteDate(LocalDateTime.now());
+        this.setUpdateDate(LocalDateTime.now());
         this.setLikedCount(0);
         return this;
     }

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/entity/board/BoardReply.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/entity/board/BoardReply.java
@@ -32,9 +32,11 @@ public class BoardReply {
     @JoinColumn(name = "MEMBER_ID")
     private Member member;
 
-    private String writeDate;
+    @Column(columnDefinition = "TIMESTAMP")
+    private LocalDateTime writeDate;
 
-    private String updateDate;
+    @Column(columnDefinition = "TIMESTAMP")
+    private LocalDateTime updateDate;
 
     @Size(min = 2, max = 500)
     private String content;
@@ -79,8 +81,8 @@ public class BoardReply {
         this.setBoard(board);
         this.setMember(member);
         this.setContent(dto.getContent());
-        this.setWriteDate(dateFormat(LocalDateTime.now()));
-        this.setUpdateDate(dateFormat(LocalDateTime.now()));
+        this.setWriteDate(LocalDateTime.now());
+        this.setUpdateDate(LocalDateTime.now());
         this.setLikedCount(0);
         this.setSeq(dto.getSeq());
         this.setDepth(dto.getDepth());
@@ -93,8 +95,8 @@ public class BoardReply {
         this.setBoard(board);
         this.setMember(member);
         this.setContent(dto.getContent());
-        this.setWriteDate(dateFormat(LocalDateTime.now()));
-        this.setUpdateDate(dateFormat(LocalDateTime.now()));
+        this.setWriteDate(LocalDateTime.now());
+        this.setUpdateDate(LocalDateTime.now());
         this.setLikedCount(10);
         this.setSeq(dto.getSeq());
         this.setDepth(dto.getDepth());
@@ -104,8 +106,8 @@ public class BoardReply {
     }
 
     public BoardReply createBoardNestedReply() {
-        this.setWriteDate(dateFormat(LocalDateTime.now()));
-        this.setUpdateDate(dateFormat(LocalDateTime.now()));
+        this.setWriteDate(LocalDateTime.now());
+        this.setUpdateDate(LocalDateTime.now());
         this.setLikedCount(0);
         this.setLevel(1);
         this.setActive("Y");
@@ -117,7 +119,7 @@ public class BoardReply {
     }
     public BoardReply editBoardReview(String content){
         this.setContent(content);
-        this.setUpdateDate(dateFormat(LocalDateTime.now()));
+        this.setUpdateDate(LocalDateTime.now());
         return this;
     }
 

--- a/StudentSoup/src/main/java/ProjectDoge/StudentSoup/repository/board/BoardRepositoryImpl.java
+++ b/StudentSoup/src/main/java/ProjectDoge/StudentSoup/repository/board/BoardRepositoryImpl.java
@@ -5,8 +5,6 @@ import ProjectDoge.StudentSoup.dto.member.MemberMyPageBoardDto;
 import ProjectDoge.StudentSoup.dto.member.QMemberMyPageBoardDto;
 import ProjectDoge.StudentSoup.entity.board.Board;
 import ProjectDoge.StudentSoup.entity.board.BoardCategory;
-import ProjectDoge.StudentSoup.entity.board.QBoardReply;
-import ProjectDoge.StudentSoup.entity.file.QImageFile;
 import ProjectDoge.StudentSoup.exception.school.SchoolIdNotSentException;
 import com.querydsl.core.types.Order;
 import com.querydsl.core.types.OrderSpecifier;
@@ -20,13 +18,10 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.support.PageableExecutionUtils;
 
 import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.Optional;
 
 import static ProjectDoge.StudentSoup.entity.board.QBoard.board;
-import static ProjectDoge.StudentSoup.entity.board.QBoardReply.boardReply;
-import static ProjectDoge.StudentSoup.entity.file.QImageFile.imageFile;
 import static ProjectDoge.StudentSoup.entity.member.QMember.member;
 import static ProjectDoge.StudentSoup.entity.school.QSchool.school;
 
@@ -87,7 +82,7 @@ public class BoardRepositoryImpl implements BoardRepositoryCustom {
                                 .and(searchColumnContainsContent(column, value))
                                 .and(searchColumnContainsNickname(column, value))
                 )
-                .orderBy(priorOrderAnnouncement(), priorTipBest(), checkSortedCondition(sorted),board.writeDate.desc())
+                .orderBy(priorOrderAnnouncement(), priorTipBest(), checkSortedCondition(sorted), board.writeDate.desc())
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
                 .fetch();
@@ -119,8 +114,7 @@ public class BoardRepositoryImpl implements BoardRepositoryCustom {
                 .from(board)
                 .where(board.school.id.eq(schoolId),
                         board.likedCount.goe(10),
-                        board.writeDate.between(searchDate.format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm")),
-                                EndDate.format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm"))))
+                        board.writeDate.between(searchDate, EndDate))
                 .offset(0)
                 .limit(5)
                 .fetch();


### PR DESCRIPTION
## 1. Changes

- 게시글 및 댓글의 작성일, 수정일 필드를 String에서 LocalDateTime(TimeStamp)로 변경하였습니다.
- 최신 글 조회 서비스 로직을 수정하였습니다.

## 2. Screenshot

-

## 3. Issues

1. 엔티티의 날짜를 수정하기 위하여 모든 필드를 다 사용하고자 String, DateTime, LocalDateTime에 대하여 모든 필드를 적용하고자 했습니다. 그러나 String을 `LocalDateTime`으로 변환하는 과정에서 최신 글을 불러오는 과정 중에 XXXX-XX-XX 의 형식은 날짜 형식으로 정렬이 되지 않는 다는 것을 발견하였습니다. 이에 따라 MYSQL에서 제공하는 함수인 `DATEFORMAT`을 사용하여
`Expressions.stringTemplate("DATE_FORMAT({0}, {1})", board.writedate, ConstantImpl.create("%Y-%m-%d"));`
를 적용해보았으나 H2 에서 테스트 하는 경우 `FORMATDATETIME` 이라는 함수를 사용하기 때문에 방언이 적용이 되지않는 현상을 발견하여 수정이 불가능하였습니다. 어떻게든 **String을 LocalDateTime으로 바꿔서 정렬하고자 하였으나**, 잘 되지 않아 모든 필드를 기존에 날짜를 비교하기 편한 `LocalDateTime`으로 수정하였습니다. 
2. 

## 4. To Reviewer

-

## 5. Plans

