### PR TITLE
Ygh/login feature

### DIFF
--- a/StudentSoup/src/main/frontend/src/apis/auth/AuthAPI.ts
+++ b/StudentSoup/src/main/frontend/src/apis/auth/AuthAPI.ts
@@ -1,11 +1,23 @@
 import axios, { type AxiosResponse } from 'axios';
 import { type SignUpUserInfo } from '../../interfaces/AuthAPITypes';
 
-export const signIn = async (id: string, password: string): Promise<AxiosResponse> => {
-  const res = await axios.post('/members/login', {
-    id,
-    pwd: password,
-  });
+export const signIn = async (id: string, password: string) => {
+  const res = await axios
+    .post('/members/login', {
+      id,
+      pwd: password,
+    })
+    .then(response => {
+      const accessToken = JSON.stringify({
+        value: response.data.accessToken,
+        expire: Date.now() + 3600000 - 300000,
+      });
+      const refreshToken = JSON.stringify(response.data.refreshToken);
+
+      localStorage.setItem('access-token', accessToken);
+      localStorage.setItem('refresh-token', refreshToken);
+    });
+
   return res;
 };
 
@@ -18,8 +30,18 @@ export const signUp = async (id: string, password: string): Promise<AxiosRespons
 };
 
 export const authRefreshToken = async (refreshToken: string) => {
-  const response = await axios.post('/jwt', { refreshtoken: JSON.parse(refreshToken) });
-  return response;
+  const res = await axios
+    .post('/jwt', {}, { headers: { Authorization: JSON.parse(refreshToken) } })
+    .then(response => {
+      const newAccessToken = JSON.stringify({
+        value: response.data,
+        expire: Date.now() + 3600000 - 300000,
+      });
+
+      localStorage.setItem('access-token', newAccessToken);
+    });
+
+  return res;
 };
 
 export const getSignUpThird = async (): Promise<AxiosResponse> => {
@@ -27,21 +49,21 @@ export const getSignUpThird = async (): Promise<AxiosResponse> => {
   return res;
 };
 
-export const postSignUpSchoolId = async (schoolId: string): Promise<AxiosResponse> => {
-  const res = await axios.post('/members/signUp/3/' + schoolId);
+export const postSignUpSchoolId = async (schoolId: number): Promise<AxiosResponse> => {
+  const res = await axios.post(`/members/signUp/3/${schoolId}`);
   return res;
 };
 
-export const signUpIdCheck = async (memberId: string): Promise<AxiosResponse> => {
+export const signUpIdCheck = async (memberId: number): Promise<AxiosResponse> => {
   const res = await axios.post('/members/signUp/2/Id', {
     memberId,
   });
   return res;
 };
 
-export const signUpNicknameCheck = async (nickname: string): Promise<AxiosResponse> => {
+export const signUpNicknameCheck = async (nickName: string): Promise<AxiosResponse> => {
   const res = await axios.post('/members/signUp/3/Nickname', {
-    nickName: nickname,
+    nickName,
   });
   return res;
 };
@@ -51,7 +73,7 @@ export const signUpEmailAuthenticate = async (
   domain: string,
 ): Promise<AxiosResponse> => {
   const res = await axios.post('/members/signUp/3/mail', {
-    email: email + '@' + domain,
+    email: `${email}@${domain}`,
   });
   return res;
 };

--- a/StudentSoup/src/main/frontend/src/apis/auth/AxiosInterceptor.ts
+++ b/StudentSoup/src/main/frontend/src/apis/auth/AxiosInterceptor.ts
@@ -12,7 +12,7 @@ axiosInstance.interceptors.request.use(
   config => {
     const accessToken: string | null = JSON.parse(localStorage.getItem('access-token') ?? 'null');
     if (accessToken) {
-      config.headers.Authorization = `Bearer ${accessToken}`;
+      config.headers.Authorization = `Bearer ${JSON.parse(accessToken)}`;
     }
 
     return config;

--- a/StudentSoup/src/main/frontend/src/apis/auth/AxiosInterceptor.ts
+++ b/StudentSoup/src/main/frontend/src/apis/auth/AxiosInterceptor.ts
@@ -2,17 +2,27 @@ import axios from 'axios';
 import { authRefreshToken } from './AuthAPI';
 
 const axiosInstance = axios.create({
-  timeout: 10000,
   headers: {
     'Content-Type': 'application/json',
   },
+  timeout: 5000,
 });
 
 axiosInstance.interceptors.request.use(
   config => {
-    const accessToken: string | null = JSON.parse(localStorage.getItem('access-token') ?? 'null');
-    if (accessToken) {
-      config.headers.Authorization = `Bearer ${JSON.parse(accessToken)}`;
+    if (localStorage.getItem('access-token') !== null) {
+      const accessToken = JSON.parse(localStorage.getItem('access-token') ?? '{}');
+      const refreshToken = localStorage.getItem('refresh-token');
+
+      if (Date.now() > accessToken.expire && refreshToken) {
+        authRefreshToken(refreshToken).then(response => {
+          const newAccessToken = JSON.parse(localStorage.getItem('access-token') ?? '{}');
+
+          config.headers.Authorization = `Bearer ${newAccessToken.value}`;
+        });
+      } else {
+        config.headers.Authorization = `Bearer ${accessToken.value}`;
+      }
     }
 
     return config;
@@ -28,22 +38,19 @@ axiosInstance.interceptors.response.use(
   },
   async error => {
     const originalRequest = error.config;
-    const refreshToken: string | null = JSON.parse(localStorage.getItem('refresh-token') ?? 'null');
+    const refreshToken = localStorage.getItem('refresh-token');
 
-    if (error.response.status === 401 && !originalRequest._retry) {
+    if (error.response.status === 403) {
       if (refreshToken) {
         originalRequest._retry = true;
 
-        try {
-          const response = await authRefreshToken(refreshToken);
-          const newAccessToken = JSON.stringify(response.data.accessToken);
-          localStorage.setItem('access-token', newAccessToken);
-          originalRequest.headers.Authorization = `Bearer ${newAccessToken}`;
+        await authRefreshToken(refreshToken).then(res => {
+          const newAccessToken = JSON.parse(localStorage.getItem('access-token') ?? '{}');
 
-          return await axiosInstance(originalRequest);
-        } catch (err) {
-          console.error('Unable to refresh token');
-        }
+          originalRequest.headers.Authorization = `Bearer ${newAccessToken.value}`;
+        });
+
+        return await axiosInstance(originalRequest);
       }
     }
 

--- a/StudentSoup/src/main/frontend/src/components/login/Login.tsx
+++ b/StudentSoup/src/main/frontend/src/components/login/Login.tsx
@@ -17,7 +17,7 @@ const Login = () => {
     toast: true,
     position: 'bottom',
     showConfirmButton: false,
-    timer: 5000,
+    timer: 4000,
     timerProgressBar: true,
   });
 
@@ -39,13 +39,13 @@ const Login = () => {
 
       signIn(userId, userPassword)
         .then(response => {
-          const accessToken = JSON.stringify(response.data.accessToken);
-          const refreshToken = JSON.stringify(response.data.refreshToken);
-          localStorage.setItem('access-token', accessToken);
-          localStorage.setItem('refresh-token', refreshToken);
           setUserId('');
           setUserPassword('');
 
+          Toast.fire({
+            icon: 'success',
+            title: '로그인을 성공하였습니다.',
+          });
           navigate('/');
         })
         .catch(error => {

--- a/StudentSoup/src/main/frontend/src/components/login/Login.tsx
+++ b/StudentSoup/src/main/frontend/src/components/login/Login.tsx
@@ -64,6 +64,11 @@ const Login = () => {
 
   useEffect(() => {
     if (localStorage.getItem('access-token')) {
+      Toast.fire({
+        icon: 'error',
+        title: '이미 로그인이 되어있습니다.',
+      });
+
       navigate('/');
     }
 


### PR DESCRIPTION
## 1. Changes

- axiosinterceptor-액세스토큰 만료시 재요청 코드 추가, 로컬스토리지 액세스토큰 만료기한 설정
- login-로그인 성공 toast 알림 추가, 로그인 상태에서 로그인 페이지 진입시 toast 알림 추가
- authAPI&login-중복되는 코드(로컬스토리지에 토큰 저장) 제거

## 2. Screenshot

- 로그인 성공시 Toast 알림 추가
![image](https://user-images.githubusercontent.com/96409594/230787335-9b09a35b-7dde-4d0a-b9ab-bb8267f45d0b.png)

- 로그인 상태에서 로그인 페이지 진입시 toast 알림 추가
![image](https://user-images.githubusercontent.com/96409594/230787361-14516792-ff11-40f4-a65d-302c7ddf7ff9.png)


## 3. Issues

1. 
2. 

## 4. To Reviewer

- @esk147 @Trophy198 

## 5. Plans
- [ ] - 
- [ ] - 
